### PR TITLE
Normalize add-on's package maven artifact

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -70,6 +70,8 @@
                   <goal>single</goal>
                 </goals>
                 <configuration>
+                  <finalName>${project.artifactId}-${project.version}</finalName>
+                  <appendAssemblyId>false</appendAssemblyId>
                   <descriptors>
                     <descriptor>src/main/assembly/packaging-archive.xml</descriptor>
                   </descriptors>


### PR DESCRIPTION
- remove the use of a maven classifier like all standard eXo add-ons
- fix the final name of the add-on archive