### PR TITLE
Import OnlyOffice API Javascript using Portlet standard API

### DIFF
--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -486,36 +486,11 @@
           "pluginsData" : []
         };
 
-        // load Onlyoffice API script:
-        // XXX need load API script to DOM head, Onlyoffice needs a real element in <script> to detect the DS server URL
-        $("<script>").attr("type", "text/javascript").attr("src", config.documentserverJsUrl).appendTo("head");
-
-        // and wait until it will be loaded
-        function jsReady() {
-          return (typeof DocsAPI !== "undefined") && (typeof DocsAPI.DocEditor !== "undefined");
-        }
-
-        var attempts = 40;
-        function waitReady() {
-          attempts--;
-          if (attempts >= 0) {
-            setTimeout(function() {
-              if (jsReady()) {
-                process.resolve(config);
-              } else {
-                waitReady();
-              }
-            }, 750);
-          } else {
-            log("ERROR: ONLYOFFICE script load timeout: " + config.documentserverJsUrl);
-            process.reject("ONLYOFFICE script load timeout. Ensure Document Server is running and accessible.");
-          }
-        }
-
-        if (jsReady()) {
-          process.resolve(config);
+        if((typeof DocsAPI === "undefined") || (typeof DocsAPI.DocEditor === "undefined")) {
+          log("ERROR: ONLYOFFICE script load timeout: " + config.documentserverJsUrl);
+          process.reject("ONLYOFFICE script load timeout. Ensure Document Server is running and accessible.");
         } else {
-          waitReady();
+          process.resolve(config);
         }
       } else {
         process.reject("Editor config not found");


### PR DESCRIPTION
The OnlyOffice API Javascript was dynamically imported from our Javascript file, which required to implement a loading strategy to wait until the script is loaded.

This change uses the standard portlet API to inject the script import in the head of the page before the page parsing (server side).
Since the load of scripts in the head of the page blocks the parsing of the page, and therefore the execution of our script, it ensures it is loaded when we need it.