### PR TITLE
Set correct test coverage ratio

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -33,7 +33,7 @@
   <description>eXo OnlyOffice Editor services of portal extension</description>
 
   <properties>
-    <exo.test.coverage.ratio>0.40</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.39</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The test coverage ratio has been raised too high in the commit 4eab6876ad0a53e6843e0222f0dd0f7803352c0b, which makes the build fails.

This fix sets the correct value for the test coverage ratio.