### PR TITLE
MAINT-24415 : add missing Download action in FileUIActivity component

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/webui/FileUIActivity.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/webui/FileUIActivity.java
@@ -57,7 +57,9 @@ import org.exoplatform.webui.core.lifecycle.UIFormLifecycle;
         @EventConfig(listeners = BaseUIActivity.DeleteCommentActionListener.class),
         @EventConfig(listeners = BaseUIActivity.LikeCommentActionListener.class),
         @EventConfig(listeners = BaseUIActivity.EditActivityActionListener.class),
-        @EventConfig(listeners = BaseUIActivity.EditCommentActionListener.class) }), })
+        @EventConfig(listeners = BaseUIActivity.EditCommentActionListener.class),
+        @EventConfig(listeners = FileUIActivity.DownloadDocumentActionListener.class)})
+})
 public class FileUIActivity extends org.exoplatform.wcm.ext.component.activity.FileUIActivity {
 
   /** The Constant LOG. */


### PR DESCRIPTION
The overrided FileUIActivity was missing the DocumentDownload action.
This PR restores it to be able to download documents when OnlyOffice is installed.