### PR TITLE
MAINT-27098 : Remove deprecated translation file

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
@@ -306,7 +306,6 @@
           <value>locale.onlyoffice.Onlyoffice</value>
           <value>locale.onlyoffice.OnlyofficeClient</value>
           <value>locale.onlyoffice.EditorsAdmin</value>
-          <value>locale.navigation.portal.intranet</value>
         </values-param>
         <values-param>
           <name>portal.resource.names</name>
@@ -314,7 +313,6 @@
           <value>locale.onlyoffice.Onlyoffice</value>
           <value>locale.onlyoffice.OnlyofficeClient</value>
           <value>locale.onlyoffice.EditorsAdmin</value>
-          <value>locale.navigation.portal.intranet</value>
         </values-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
intranet.properties file is no more needed, thus we remove it