### PR TITLE
MAINT-40127 : fix onlyofffice preview height style override

### DIFF
--- a/webapp/src/main/webapp/skin/onlyoffice-extras.css
+++ b/webapp/src/main/webapp/skin/onlyoffice-extras.css
@@ -65,7 +65,7 @@
 
 .onlyofficeViewerContainer {
   width: 100%;
-  height: 100%;
+  height: 100% !important;
   position: relative;
   min-width: 665px;
   margin-bottom: 15px;
@@ -75,7 +75,6 @@
   height: 100%;
   width: 100%;
 }
-
 .onlyoffice-no-preview {
   background-color: white;
   position: relative;


### PR DESCRIPTION
This Pr should ajust the onlyoffice popup previewer height style by protecting this property from being overrided by some other styles 