### PR TITLE
MAINT-47888: Fix xlsx and pptx documents recent versions visualize with onlyOffice previewer

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -1645,12 +1645,11 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       title = node.getProperty("exo:name").getString();
     }
     if (title == null) {
-      title = node.getName();
-    }
-    try {
-      title = URLDecoder.decode(node.getName(), UTF_8);
-    } catch (UnsupportedEncodingException e) {
-      LOG.warn("Cannot decode node name using URLDecoder. {}", e.getMessage());
+      try {
+        title = URLDecoder.decode(node.getName(), UTF_8);
+      } catch (UnsupportedEncodingException e) {
+        LOG.warn("Cannot decode node name using URLDecoder. {}", e.getMessage());
+      }
     }
     return title;
   }


### PR DESCRIPTION
**ISSUE** : when creating the viewer of a recent version file there was a problem in getting file type in `OnlyofficeEditorService.fileType() method` because its' extracting the type via the file extension in the name which leads to the problem in the `OnlyofficeEditorService.nodeTitle() method` it deosn't work properly because it's getting the **exo:title**  or **jcr:content/dc:title"** property and than override it by `node.getName` without any reason.
this causes issue only with the recent versions because `node.getName` is "**jcr:frozenNode**" and not the name of the file
**FIX**: correct the method `OnlyofficeEditorService.nodeTitle()` by correctly place the case of getting **nodeName**() when the property **exo:title** and  **jcr:content/dc:title"** and **exo:name** are **null**.

**The type of the file is important to allow onlyoffice server to send the right previewer** 