### PR TITLE
MAINT-40982: Allow onlyoffice mobile embed type for documents previewing on mobile devices

### DIFF
--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -156,7 +156,13 @@
   };
 
   const DESKTOP_MODE = "desktop";
-  const EMBEDDED_MODE = "embedded";
+  let EMBEDDED_MODE = "";
+  if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+    EMBEDDED_MODE = "mobile";
+  } else {
+    EMBEDDED_MODE = "embedded";
+  }
+
 
   /**
    * Editor core class.

--- a/webapp/src/main/webapp/skin/onlyoffice-extras.css
+++ b/webapp/src/main/webapp/skin/onlyoffice-extras.css
@@ -67,7 +67,6 @@
   width: 100%;
   height: 100%;
   position: relative;	
-  min-width: 665px;
 }
 
 #UIDocumentContainer .onlyofficeViewerContainer {
@@ -89,4 +88,7 @@
   top: 40%; left: 50%;
   transform: translate(-40%,-50%);
   width: 80%;
+}
+iframe[name="frameEditor"] {
+  position: relative !important;
 }


### PR DESCRIPTION
**ISSUE**: The onlyoffice embed type was always set to embedded even on mobile devices.
**FIX**: Change embed mode to mobile in mobile devices.