### PR TITLE
MAINT-49438: Fix onlyoffice editor display on mozilla browser

### DIFF
--- a/webapp/src/main/webapp/skin/onlyoffice-extras.css
+++ b/webapp/src/main/webapp/skin/onlyoffice-extras.css
@@ -91,4 +91,5 @@
 }
 iframe[name="frameEditor"] {
   position: relative !important;
+  height: inherit !important;
 }


### PR DESCRIPTION
**ISSUE**: The display of the embedded iframe on mozilla wasn't okay after the last changes made to allow the mobile embed
**FIX**: Adjust the height style to fix the display on mozilla browser