### PR TITLE
Task-51803 :Full screen button should be removed from a document preview

### DIFF
--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -500,7 +500,6 @@
         config.height = "100%";
         config.width = "100%";
         config.editorConfig.embedded = {
-          fullscreenUrl: config.editorUrl,
           saveUrl: config.downloadUrl,
           toolbarDocked: "top"
         };


### PR DESCRIPTION
Problem :full screen button is displayed and opens the edition mode of document with the following error message:"Failed to create editor's configuration"
Fix :Remove embedded full screen button In fact this button has the functionality to open the OnlyOffice editor which is doable with the "Edit" button in the toolbar and which is displayed only for users with read/write permission