### PR TITLE
Task-49508 : In some extremes cases modifications can be losts (#127)

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -169,6 +169,10 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.exoplatform.social</groupId>
+      <artifactId>social-component-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -217,6 +221,10 @@
             <include>**/**/OnlyofficeEditorServiceTest.java</include>
           </includes>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.jcabi</groupId>
+        <artifactId>jcabi-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/services/src/main/java/org/exoplatform/onlyoffice/Config.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/Config.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
@@ -56,6 +57,16 @@ public class Config implements Externalizable {
 
   /** The Constant EMPTY. */
   protected static final String           EMPTY           = "".intern();
+
+  protected Long databaseId;
+
+  public Long getDatabaseId() {
+    return databaseId;
+  }
+
+  public void setDatabaseId(Long databaseId) {
+    this.databaseId = databaseId;
+  }
 
   /**
    * The Class Builder.
@@ -187,6 +198,16 @@ public class Config implements Externalizable {
       return this;
     }
 
+    public Builder explorerUri(String url) {
+      try {
+        this.explorerUri(new URI(url));
+      } catch (URISyntaxException e) {
+        LOG.error("Unable to create URI from url {}", url);
+        this.explorerUri=null;
+      }
+      return this;
+    }
+
     /**
      * Title.
      *
@@ -253,6 +274,10 @@ public class Config implements Externalizable {
       return this;
     }
 
+    public Builder uploaded(String date) {
+      this.uploaded = date;
+      return this;
+    }
     /**
      * Display path.
      *
@@ -977,7 +1002,7 @@ public class Config implements Externalizable {
    * @param docId the document ID
    * @return the builder
    */
-  protected static Builder editor(String documentserverUrl, String documentType, String workspace, String path, String docId) {
+  public static Builder editor(String documentserverUrl, String documentType, String workspace, String path, String docId) {
     return new Builder(documentserverUrl, documentType, workspace, path, docId);
   }
 
@@ -1007,6 +1032,10 @@ public class Config implements Externalizable {
 
   /** The Document Server URL. */
   private String                          documentserverUrl, documentserverJsUrl;
+
+  public String getPlatformRestUrl() {
+    return platformRestUrl;
+  }
 
   /** The Platform REST URL base (to generate file URLs for users). */
   private String                          platformRestUrl;
@@ -1419,7 +1448,7 @@ public class Config implements Externalizable {
    *
    * @param openedTime the openedTime
    */
-  protected void setOpenedTime(Long openedTime) {
+  public void setOpenedTime(Long openedTime) {
     this.openedTime = openedTime;
   }
 
@@ -1428,7 +1457,7 @@ public class Config implements Externalizable {
    *
    * @param closedTime the closedTime
    */
-  protected void setClosedTime(Long closedTime) {
+  public void setClosedTime(Long closedTime) {
     this.closedTime = closedTime;
   }
 
@@ -1581,6 +1610,10 @@ public class Config implements Externalizable {
     this.openedTime = System.currentTimeMillis();
   }
 
+  public void setOpen(boolean open) {
+    this.open=open;
+  }
+
   /**
    * Mark this config as closing: user already closed this editor but document
    * not yet saved in the storage. This state is actual for last user who will
@@ -1593,6 +1626,10 @@ public class Config implements Externalizable {
       this.closing = new Boolean(true);
       this.closedTime = System.currentTimeMillis();
     }
+  }
+
+  public void setClosing(boolean closing) {
+    this.closing=closing;
   }
 
   /**
@@ -1612,7 +1649,7 @@ public class Config implements Externalizable {
    *
    * @param error the new error
    */
-  protected void setError(String error) {
+  public void setError(String error) {
     this.error = error;
   }
 

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
@@ -380,4 +380,7 @@ public interface OnlyofficeEditorService {
    */
   void addFilePreferences(Node node, String userId, String path) throws RepositoryException;
 
+  String getDocumentServiceSecret();
+
+  void closeWithoutModification(String userId, String key);
 }

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/EditorConfigDAO.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/EditorConfigDAO.java
@@ -1,0 +1,13 @@
+package org.exoplatform.onlyoffice.jpa;
+
+import org.exoplatform.commons.api.persistence.GenericDAO;
+import org.exoplatform.onlyoffice.jpa.entities.EditorConfigEntity;
+
+import java.util.List;
+
+public interface EditorConfigDAO extends GenericDAO<EditorConfigEntity,Long> {
+
+  List<EditorConfigEntity> getConfigByKey(String key);
+  List<EditorConfigEntity> getConfigByDocId(String docId);
+
+}

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/EditorConfigStorage.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/EditorConfigStorage.java
@@ -1,0 +1,17 @@
+package org.exoplatform.onlyoffice.jpa;
+
+import org.exoplatform.onlyoffice.Config;
+
+import java.util.List;
+import java.util.Map;
+
+public interface EditorConfigStorage {
+
+  Map<String,Config> getConfigsByKey(String key);
+  Map<String,Config> getConfigsByDocId(String docId);
+  void saveConfig(String key, Config config, boolean isNew);
+  void saveConfig(List<String> keys, Config config, boolean isNew);
+  void deleteConfig(String key, Config config);
+  void deleteConfig(List<String> keys, Config config);
+
+}

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/dao/EditorConfigDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/dao/EditorConfigDAOImpl.java
@@ -1,0 +1,27 @@
+package org.exoplatform.onlyoffice.jpa.dao;
+
+import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
+import org.exoplatform.onlyoffice.jpa.EditorConfigDAO;
+import org.exoplatform.onlyoffice.jpa.entities.EditorConfigEntity;
+
+import javax.persistence.TypedQuery;
+import java.util.List;
+
+public class EditorConfigDAOImpl extends GenericDAOJPAImpl<EditorConfigEntity, Long> implements EditorConfigDAO {
+
+  @Override
+  public List<EditorConfigEntity> getConfigByKey(String key) {
+    TypedQuery<EditorConfigEntity> query = getEntityManager()
+        .createNamedQuery("EditorConfigEntity.getConfigByKey",EditorConfigEntity.class);
+    query.setParameter("key", key);
+    return query.getResultList();
+  }
+
+  @Override
+  public List<EditorConfigEntity> getConfigByDocId(String docId) {
+    TypedQuery<EditorConfigEntity> query = getEntityManager()
+        .createNamedQuery("EditorConfigEntity.getConfigByDocId",EditorConfigEntity.class);
+    query.setParameter("docId", docId);
+    return query.getResultList();
+  }
+}

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/entities/EditorConfigEntity.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/entities/EditorConfigEntity.java
@@ -1,0 +1,454 @@
+package org.exoplatform.onlyoffice.jpa.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import org.exoplatform.commons.api.persistence.ExoEntity;
+
+@Entity(name = "EditorConfigEntity")
+@ExoEntity
+@Table(name = "OO_EDITOR_CONFIG")
+@NamedQueries({
+    @NamedQuery(name = "EditorConfigEntity.getConfigByKey", query = "SELECT e FROM EditorConfigEntity e WHERE e.documentKey = :key"),
+    @NamedQuery(name = "EditorConfigEntity.getConfigByDocId", query = "SELECT e FROM EditorConfigEntity e WHERE e.documentId = :docId")
+})
+public class EditorConfigEntity {
+  @Id
+  @SequenceGenerator(name = "SEQ_OO_EDITOR_CONFIG_ID", sequenceName = "SEQ_OO_EDITOR_CONFIG_ID")
+  @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_OO_EDITOR_CONFIG_ID")
+  @Column(name = "ID")
+  private Long id;
+
+  @Column(name = "DOCUMENT_ID")
+  private String documentId;
+
+  @Column(name = "WORKSPACE")
+  private String workspace;
+
+  @Column(name = "PATH")
+  private String path;
+
+  @Column(name = "DOCUMENT_TYPE")
+  private String documentType;
+
+  @Column(name = "DOCUMENT_SERVER_URL")
+  private String documentServerUrl;
+
+  @Column(name = "PLATFORM_REST_URL")
+  private String platformRestUrl;
+
+  @Column(name = "EDITOR_URL")
+  private String editorUrl;
+
+  @Column(name = "DOWNLOAD_URL")
+  private String downloadUrl;
+
+  @Column(name = "EXPLORER_URL")
+  private String explorerUrl;
+
+  @Column(name = "IS_ACTIVITY")
+  private boolean isActivity;
+
+  @Column(name = "ERROR")
+  private String error;
+
+  @Column(name = "OPEN")
+  private boolean open;
+
+  @Column(name = "CLOSING")
+  private boolean closing;
+
+  @Column(name = "OPENED_TIME")
+  private Long openedTime;
+
+  @Column(name = "CLOSED_TIME")
+  private Long closedTime;
+
+  @Column(name = "EDITOR_PAGE_LAST_MODIFIER")
+  private String editorPageLastModifier;
+
+  @Column(name = "EDITOR_PAGE_LAST_MODIFIED")
+  private String editorPageLastModified;
+
+  @Column(name = "EDITOR_PAGE_DISPLAY_PATH")
+  private String editorPageDisplayPath;
+
+  @Column(name = "EDITOR_PAGE_COMMENT")
+  private String editorPageComment;
+
+  @Column(name = "EDITOR_PAGE_DRIVE")
+  private String editorPageDrive;
+
+  @Column(name = "EDITOR_PAGE_RENAMED_ALLOWED")
+  private boolean editorPageRenamedAllowed;
+
+  @Column(name = "DOCUMENT_FILETYPE")
+  private String documentFileType;
+
+  @Column(name = "DOCUMENT_KEY")
+  private String documentKey;
+
+  @Column(name = "DOCUMENT_TITLE")
+  private String documentTitle;
+
+  @Column(name = "DOCUMENT_URL")
+  private String documentUrl;
+
+  @Column(name = "DOCUMENT_INFO_OWNER")
+  private String documentInfoOwner;
+
+  @Column(name = "DOCUMENT_INFO_UPLOADED")
+  private String documentInfoUploaded;
+
+  @Column(name = "DOCUMENT_INFO_FOLDER")
+  private String documentInfoFolder;
+
+  @Column(name = "PERMISSION_ALLOWEDIT")
+  private boolean permissionAllowEdit;
+
+  @Column(name = "EDITOR_CALLBACKURL")
+  private String editorCallbackUrl;
+
+  @Column(name = "EDITOR_LANG")
+  private String editorLang;
+
+  @Column(name = "EDITOR_MODE")
+  private String editorMode;
+
+  @Column(name = "EDITOR_USER_USERID")
+  private String editorUserUserid;
+
+  @Column(name = "EDITOR_USER_NAME")
+  private String editorUserName;
+
+  @Column(name = "EDITOR_USER_LASTMODIFIED")
+  private long editorUserLastModified;
+
+  @Column(name = "EDITOR_USER_LASTSAVED")
+  private long editorUserLastSaved;
+
+  @Column(name = "EDITOR_USER_LINKSAVED")
+  private long editorUserLinkSaved;
+
+  @Column(name = "EDITOR_USER_DOWNLOAD_LINK")
+  private String editorUserDownloadLink;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getDocumentId() {
+    return documentId;
+  }
+
+  public void setDocumentId(String documentId) {
+    this.documentId = documentId;
+  }
+
+  public String getWorkspace() {
+    return workspace;
+  }
+
+  public void setWorkspace(String workspace) {
+    this.workspace = workspace;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getDocumentType() {
+    return documentType;
+  }
+
+  public void setDocumentType(String documentType) {
+    this.documentType = documentType;
+  }
+
+  public String getDocumentServerUrl() {
+    return documentServerUrl;
+  }
+
+  public void setDocumentServerUrl(String documentServerUrl) {
+    this.documentServerUrl = documentServerUrl;
+  }
+
+  public String getPlatformRestUrl() {
+    return platformRestUrl;
+  }
+
+  public void setPlatformRestUrl(String platformRestUrl) {
+    this.platformRestUrl = platformRestUrl;
+  }
+
+  public String getEditorUrl() {
+    return editorUrl;
+  }
+
+  public void setEditorUrl(String editorUrl) {
+    this.editorUrl = editorUrl;
+  }
+
+  public String getDownloadUrl() {
+    return downloadUrl;
+  }
+
+  public void setDownloadUrl(String downloadUrl) {
+    this.downloadUrl = downloadUrl;
+  }
+
+  public String getExplorerUrl() {
+    return explorerUrl;
+  }
+
+  public void setExplorerUrl(String explorerUrl) {
+    this.explorerUrl = explorerUrl;
+  }
+
+  public boolean isActivity() {
+    return isActivity;
+  }
+
+  public void setActivity(boolean activity) {
+    isActivity = activity;
+  }
+
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+
+  public boolean isOpen() {
+    return open;
+  }
+
+  public void setOpen(boolean open) {
+    this.open = open;
+  }
+
+  public boolean isClosing() {
+    return closing;
+  }
+
+  public void setClosing(boolean closing) {
+    this.closing = closing;
+  }
+
+  public Long getOpenedTime() {
+    return openedTime;
+  }
+
+  public void setOpenedTime(Long openedTime) {
+    this.openedTime = openedTime;
+  }
+
+  public Long getClosedTime() {
+    return closedTime;
+  }
+
+  public void setClosedTime(Long closedTime) {
+    this.closedTime = closedTime;
+  }
+
+  public String getEditorPageLastModifier() {
+    return editorPageLastModifier;
+  }
+
+  public void setEditorPageLastModifier(String editorPageLastModifier) {
+    this.editorPageLastModifier = editorPageLastModifier;
+  }
+
+  public String getEditorPageLastModified() {
+    return editorPageLastModified;
+  }
+
+  public void setEditorPageLastModified(String editorPageLastModified) {
+    this.editorPageLastModified = editorPageLastModified;
+  }
+
+  public String getEditorPageDisplayPath() {
+    return editorPageDisplayPath;
+  }
+
+  public void setEditorPageDisplayPath(String editorPageDisplayPath) {
+    this.editorPageDisplayPath = editorPageDisplayPath;
+  }
+
+  public String getEditorPageComment() {
+    return editorPageComment;
+  }
+
+  public void setEditorPageComment(String editorPageComment) {
+    this.editorPageComment = editorPageComment;
+  }
+
+  public String getEditorPageDrive() {
+    return editorPageDrive;
+  }
+
+  public void setEditorPageDrive(String editorPageDrive) {
+    this.editorPageDrive = editorPageDrive;
+  }
+
+  public boolean isEditorPageRenamedAllowed() {
+    return editorPageRenamedAllowed;
+  }
+
+  public void setEditorPageRenamedAllowed(boolean editorPageRenamedAllowed) {
+    this.editorPageRenamedAllowed = editorPageRenamedAllowed;
+  }
+
+  public String getDocumentFileType() {
+    return documentFileType;
+  }
+
+  public void setDocumentFileType(String documentFileType) {
+    this.documentFileType = documentFileType;
+  }
+
+  public String getDocumentKey() {
+    return documentKey;
+  }
+
+  public void setDocumentKey(String documentKey) {
+    this.documentKey = documentKey;
+  }
+
+  public String getDocumentTitle() {
+    return documentTitle;
+  }
+
+  public void setDocumentTitle(String documentTitle) {
+    this.documentTitle = documentTitle;
+  }
+
+  public String getDocumentUrl() {
+    return documentUrl;
+  }
+
+  public void setDocumentUrl(String documentUrl) {
+    this.documentUrl = documentUrl;
+  }
+
+  public String getDocumentInfoOwner() {
+    return documentInfoOwner;
+  }
+
+  public void setDocumentInfoOwner(String documentInfoOwner) {
+    this.documentInfoOwner = documentInfoOwner;
+  }
+
+  public String getDocumentInfoUploaded() {
+    return documentInfoUploaded;
+  }
+
+  public void setDocumentInfoUploaded(String documentInfoUploaded) {
+    this.documentInfoUploaded = documentInfoUploaded;
+  }
+
+  public String getDocumentInfoFolder() {
+    return documentInfoFolder;
+  }
+
+  public void setDocumentInfoFolder(String documentInfoFolder) {
+    this.documentInfoFolder = documentInfoFolder;
+  }
+
+  public boolean isPermissionAllowEdit() {
+    return permissionAllowEdit;
+  }
+
+  public void setPermissionAllowEdit(boolean permissionAllowEdit) {
+    this.permissionAllowEdit = permissionAllowEdit;
+  }
+
+  public String getEditorCallbackUrl() {
+    return editorCallbackUrl;
+  }
+
+  public void setEditorCallbackUrl(String editorCallbackUrl) {
+    this.editorCallbackUrl = editorCallbackUrl;
+  }
+
+  public String getEditorLang() {
+    return editorLang;
+  }
+
+  public void setEditorLang(String editorLang) {
+    this.editorLang = editorLang;
+  }
+
+  public String getEditorMode() {
+    return editorMode;
+  }
+
+  public void setEditorMode(String editorMode) {
+    this.editorMode = editorMode;
+  }
+
+  public String getEditorUserUserid() {
+    return editorUserUserid;
+  }
+
+  public void setEditorUserUserid(String editorUserUserid) {
+    this.editorUserUserid = editorUserUserid;
+  }
+
+  public String getEditorUserName() {
+    return editorUserName;
+  }
+
+  public void setEditorUserName(String editorUserName) {
+    this.editorUserName = editorUserName;
+  }
+
+  public long getEditorUserLastModified() {
+    return editorUserLastModified;
+  }
+
+  public void setEditorUserLastModified(long editorUserLastModified) {
+    this.editorUserLastModified = editorUserLastModified;
+  }
+
+  public long getEditorUserLastSaved() {
+    return editorUserLastSaved;
+  }
+
+  public void setEditorUserLastSaved(long editorUserLastSaved) {
+    this.editorUserLastSaved = editorUserLastSaved;
+  }
+
+  public long getEditorUserLinkSaved() {
+    return editorUserLinkSaved;
+  }
+
+  public void setEditorUserLinkSaved(long editorUserLinkSaved) {
+    this.editorUserLinkSaved = editorUserLinkSaved;
+  }
+
+  public String getEditorUserDownloadLink() {
+    return editorUserDownloadLink;
+  }
+
+  public void setEditorUserDownloadLink(String editorUserDownloadLink) {
+    this.editorUserDownloadLink = editorUserDownloadLink;
+  }
+}

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/cache/CachedEditorConfigStorage.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/cache/CachedEditorConfigStorage.java
@@ -1,0 +1,75 @@
+package org.exoplatform.onlyoffice.jpa.storage.cache;
+
+import org.exoplatform.onlyoffice.Config;
+import org.exoplatform.onlyoffice.jpa.EditorConfigStorage;
+import org.exoplatform.onlyoffice.jpa.storage.impl.RDBMSEditorConfigStorageImpl;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
+
+import java.util.List;
+import java.util.Map;
+
+public class CachedEditorConfigStorage implements EditorConfigStorage {
+
+  private EditorConfigStorage storage;
+
+  private final ExoCache<String, Map<String, Config>> configCache;
+
+  public static final String     CACHE_NAME               = "onlyoffice.EditorCache";
+
+
+  public CachedEditorConfigStorage(final RDBMSEditorConfigStorageImpl storage, CacheService cacheService) {
+    this.storage = storage;
+    configCache = cacheService.getCacheInstance(CACHE_NAME);
+  }
+
+  @Override
+  public Map<String, Config> getConfigsByKey(String key) {
+    Map<String, Config> configs = configCache.get(key);
+    if (configs != null) {
+      return configs;
+    }
+    configs = storage.getConfigsByKey(key);
+    if (configs != null && !configs.isEmpty()) {
+      configCache.put(key, configs);
+    }
+    return configs;
+  }
+
+  @Override
+  public Map<String, Config> getConfigsByDocId(String docId) {
+    Map<String, Config> configs = configCache.get(docId);
+    if (configs != null) {
+      return configs;
+    }
+    configs = storage.getConfigsByDocId(docId);
+    if (configs != null && !configs.isEmpty()) {
+      configCache.put(docId, configs);
+    }
+    return configs;
+  }
+
+  @Override
+  public void saveConfig(String key, Config config, boolean isNew) {
+    storage.saveConfig(key,config,isNew);
+    configCache.remove(key);
+  }
+
+  @Override
+  public void saveConfig(List<String> keys, Config config, boolean isNew) {
+    storage.saveConfig(keys,config,isNew);
+    keys.forEach(configCache::remove);
+  }
+
+  @Override
+  public void deleteConfig(String key, Config config) {
+    storage.deleteConfig(key,config);
+    configCache.remove(key);
+  }
+
+  @Override
+  public void deleteConfig(List<String> keys, Config config) {
+    storage.deleteConfig(keys,config);
+    keys.forEach(configCache::remove);
+  }
+}

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/impl/RDBMSEditorConfigStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/impl/RDBMSEditorConfigStorageImpl.java
@@ -1,0 +1,178 @@
+package org.exoplatform.onlyoffice.jpa.storage.impl;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.onlyoffice.Config;
+import org.exoplatform.onlyoffice.OnlyofficeEditorService;
+import org.exoplatform.onlyoffice.jpa.EditorConfigDAO;
+import org.exoplatform.onlyoffice.jpa.EditorConfigStorage;
+import org.exoplatform.onlyoffice.jpa.entities.EditorConfigEntity;
+
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RDBMSEditorConfigStorageImpl implements EditorConfigStorage {
+
+  private final EditorConfigDAO editorConfigDAO;
+
+  public RDBMSEditorConfigStorageImpl (EditorConfigDAO editorConfigDAO) {
+    this.editorConfigDAO=editorConfigDAO;
+  }
+  @Override
+  @ExoTransactional
+  public Map<String,Config> getConfigsByKey(String key) {
+    List<EditorConfigEntity> entities = editorConfigDAO.getConfigByKey(key);
+    return entities.stream()
+                   .collect(Collectors.toMap(EditorConfigEntity::getEditorUserUserid,
+                                             this::buildFromEntity));
+  }
+
+  @Override
+  @ExoTransactional
+  public Map<String,Config> getConfigsByDocId(String docId) {
+    List<EditorConfigEntity> entities = editorConfigDAO.getConfigByDocId(docId);
+    return entities.stream()
+                   .collect(Collectors.toConcurrentMap(EditorConfigEntity::getEditorUserUserid,
+                                                       this::buildFromEntity));  }
+
+
+
+  @Override
+  @ExoTransactional
+  public void saveConfig(String key, Config config, boolean isNew) {
+    if (isNew) {
+      EditorConfigEntity entity = buildFromDTO(config);
+      editorConfigDAO.create(entity);
+      config.setDatabaseId(entity.getId());
+    } else {
+      EditorConfigEntity entity = editorConfigDAO.find(config.getDatabaseId());
+      if (entity!=null) {
+        entity = buildFromDTO(config);
+        editorConfigDAO.update(entity);
+      } else {
+        throw new RuntimeException("Unable to save OO Config");
+      }
+    }
+  }
+
+  @Override
+  public void saveConfig(List<String> keys, Config config, boolean isNew) {
+    this.saveConfig("", config, isNew);
+  }
+
+  @Override
+  @ExoTransactional
+  public void deleteConfig(String key, Config config) {
+    EditorConfigEntity entity = editorConfigDAO.find(config.getDatabaseId());
+    if (entity!=null) {
+      editorConfigDAO.delete(entity);
+    }
+  }
+  @Override
+  public void deleteConfig(List<String> keys, Config config) {
+    this.deleteConfig("",config);
+  }
+
+
+  private EditorConfigEntity buildFromDTO(Config config) {
+    EditorConfigEntity result = new EditorConfigEntity();
+
+    result.setId(config.getDatabaseId());
+
+    result.setDocumentId(config.getDocId());
+    result.setWorkspace(config.getWorkspace());
+    result.setPath(config.getPath());
+    result.setDocumentType(config.getDocumentType());
+    result.setDocumentServerUrl(config.getDocumentserverUrl());
+    result.setPlatformRestUrl(config.getPlatformRestUrl());
+    result.setEditorUrl(config.getEditorUrl());
+    result.setDownloadUrl(config.getDownloadUrl());
+    result.setExplorerUrl(config.getExplorerUrl());
+    result.setActivity(config.isActivity());
+    result.setError(config.getError());
+    result.setOpen(config.isOpen());
+    result.setClosing(config.isClosing());
+    result.setOpenedTime(config.getOpenedTime());
+    result.setClosedTime(config.getClosedTime());
+    result.setEditorPageLastModifier(config.getEditorPage().getLastModifier());
+    result.setEditorPageLastModified(config.getEditorPage().getLastModified());
+    result.setEditorPageDisplayPath(config.getEditorPage().getDisplayPath());
+    result.setEditorPageComment(config.getEditorPage().getComment());
+    result.setEditorPageDrive(config.getEditorPage().getDrive());
+    result.setEditorPageRenamedAllowed(config.getEditorPage().getRenameAllowed());
+    result.setDocumentFileType(config.getDocument().getFileType());
+    result.setDocumentKey(config.getDocument().getKey());
+    result.setDocumentTitle(config.getDocument().getTitle());
+    result.setDocumentUrl(config.getDocument().getUrl());
+    result.setDocumentInfoOwner(config.getDocument().getInfo().getOwner());
+    result.setDocumentInfoUploaded(config.getDocument().getInfo().getUploaded());
+    result.setDocumentInfoFolder(config.getDocument().getInfo().getFolder());
+    result.setPermissionAllowEdit(config.getDocument().getPermissions().isEdit());
+    result.setEditorCallbackUrl(config.getEditorConfig().getCallbackUrl());
+    result.setEditorLang(config.getEditorConfig().getLang());
+    result.setEditorMode(config.getEditorConfig().getMode());
+    result.setEditorUserUserid(config.getEditorConfig().getUser().getId());
+    result.setEditorUserName(config.getEditorConfig().getUser().getName());
+    result.setEditorUserLastModified(config.getEditorConfig().getUser().getLastModified());
+    result.setEditorUserLastSaved(config.getEditorConfig().getUser().getLastSaved());
+    result.setEditorUserLinkSaved(config.getEditorConfig().getUser().getLinkSaved());
+    result.setEditorUserDownloadLink(config.getEditorConfig().getUser().getDownloadLink());
+
+    return result;
+
+
+  }
+
+
+  private Config buildFromEntity(EditorConfigEntity entity) {
+
+
+    Config.Builder builder = Config.editor(entity.getDocumentServerUrl(), entity.getDocumentType(),
+                                           entity.getWorkspace(), entity.getPath(), entity.getDocumentId());
+    builder.owner(entity.getEditorUserUserid());
+    builder.fileType(entity.getDocumentFileType());
+    builder.uploaded(entity.getDocumentInfoUploaded());
+    builder.displayPath(entity.getEditorPageDisplayPath());
+    builder.comment(entity.getEditorPageComment());
+    builder.drive(entity.getEditorPageDrive());
+    builder.renameAllowed(entity.isEditorPageRenamedAllowed());
+    builder.isActivity(entity.isActivity());
+    builder.folder(entity.getDocumentInfoFolder());
+    builder.lang(entity.getEditorLang());
+    builder.mode(entity.getEditorMode());
+    builder.title(entity.getDocumentTitle());
+    builder.userId(entity.getEditorUserUserid());
+    builder.userName(entity.getEditorUserName());
+    builder.lastModifier(entity.getEditorPageLastModifier());
+    builder.lastModified(entity.getEditorPageLastModified());
+    builder.key(entity.getDocumentKey());
+    builder.generateUrls(entity.getPlatformRestUrl());
+    builder.editorUrl(entity.getEditorUrl());
+    builder.explorerUri(entity.getExplorerUrl());
+    builder.secret(getDocumentServiceSecret());
+    builder.setAllowEdition(entity.isPermissionAllowEdit());
+
+    Config result = builder.build();
+    result.setError(entity.getError());
+    result.setDatabaseId(entity.getId());
+    result.setOpen(entity.isOpen());
+    result.setClosing(entity.isClosing());
+    result.setOpenedTime(entity.getOpenedTime());
+    result.setClosedTime(entity.getClosedTime());
+
+    result.getEditorConfig().getUser().setLastModified(entity.getEditorUserLastModified());
+    result.getEditorConfig().getUser().setLastSaved(entity.getEditorUserLastSaved());
+    result.getEditorConfig().getUser().setLinkSaved(entity.getEditorUserLinkSaved());
+    result.getEditorConfig().getUser().setDownloadLink(entity.getEditorUserDownloadLink());
+    return result;
+  }
+
+  private String getDocumentServiceSecret() {
+    ExoContainer container = ExoContainerContext.getCurrentContainer();
+    OnlyofficeEditorService editorService = container.getComponentInstanceOfType(OnlyofficeEditorService.class);
+    return editorService.getDocumentServiceSecret();
+  }
+}

--- a/services/src/main/resources/conf/portal/configuration.xml
+++ b/services/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+    <component>
+        <key>org.exoplatform.onlyoffice.jpa.EditorConfigDAO</key>
+        <type>org.exoplatform.onlyoffice.jpa.dao.EditorConfigDAOImpl</type>
+    </component>
+
+    <component>
+        <type>org.exoplatform.onlyoffice.jpa.storage.impl.RDBMSEditorConfigStorageImpl</type>
+    </component>
+
+    <component>
+        <key>org.exoplatform.onlyoffice.jpa.EditorConfigStorage</key>
+        <type>org.exoplatform.onlyoffice.jpa.storage.cache.CachedEditorConfigStorage</type>
+    </component>
+
+    <external-component-plugins>
+        <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
+        <component-plugin>
+            <name>AppCenterChangeLogsPlugin</name>
+            <set-method>addChangeLogsPlugin</set-method>
+            <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+            <init-params>
+                <values-param>
+                    <name>changelogs</name>
+                    <description>Change logs of onlyoffice</description>
+                    <value>db.changelogs/onlyoffice-changelog-1.0.0.xml</value>
+                </values-param>
+            </init-params>
+        </component-plugin>
+    </external-component-plugins>
+
+</configuration>

--- a/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
+++ b/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <!-- Managing both DB that use sequences and db that use auto increment -->
+  <property name="autoIncrement" value="true" dbms="mysql,mssql,h2,sybase,db2,hsqldb" />
+  <property name="autoIncrement" value="false" dbms="oracle,postgresql" />
+
+    <!-- Managing auto generation of timestamp by Database -->
+  <property name="now" value="now()" dbms="mysql,hsqldb,postgresql,h2" />
+  <property name="now" value="sysdate" dbms="oracle" />
+  <property name="now" value="CURRENT_TIMESTAMP" dbms="mssql" />
+
+  <changeSet author="onlyoffice" id="1.0.0-1" onValidationFail="MARK_RAN">
+    <preConditions onFail="MARK_RAN" onError="MARK_RAN">
+      <not>
+        <tableExists tableName="OO_EDITOR_CONFIG" />
+      </not>
+    </preConditions>
+    <createTable tableName="OO_EDITOR_CONFIG">
+      <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="PK_OO_EDITOR_CONFIG_ID" />
+      </column>
+      <column name="DOCUMENT_ID" type="VARCHAR(64)">
+      </column>
+      <column name="WORKSPACE" type="VARCHAR(250)">
+      </column>
+      <column name="PATH" type="VARCHAR(500)">
+      </column>
+      <column name="DOCUMENT_TYPE" type="VARCHAR(100)">
+      </column>
+      <column name="DOCUMENT_SERVER_URL" type="VARCHAR(250)">
+      </column>
+      <column name="PLATFORM_REST_URL" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_URL" type="VARCHAR(250)">
+      </column>
+      <column name="DOWNLOAD_URL" type="VARCHAR(250)">
+      </column>
+      <column name="EXPLORER_URL" type="VARCHAR(250)">
+      </column>
+      <column name="IS_ACTIVITY" type="BOOLEAN" defaultValueBoolean="false">
+      </column>
+      <column name="ERROR" type="VARCHAR(500)">
+      </column>
+      <column name="OPEN" type="BOOLEAN">
+      </column>
+      <column name="CLOSING" type="BOOLEAN">
+      </column>
+      <column name="OPENED_TIME" type="BIGINT">
+      </column>
+      <column name="CLOSED_TIME" type="BIGINT">
+      </column>
+      <column name="EDITOR_PAGE_LAST_MODIFIER" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_PAGE_LAST_MODIFIED" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_PAGE_DISPLAY_PATH" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_PAGE_COMMENT" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_PAGE_DRIVE" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_PAGE_RENAMED_ALLOWED" type="BOOLEAN">
+      </column>
+      <column name="DOCUMENT_FILETYPE" type="VARCHAR(250)">
+      </column>
+      <column name="DOCUMENT_KEY" type="VARCHAR(250)">
+      </column>
+      <column name="DOCUMENT_TITLE" type="VARCHAR(250)">
+      </column>
+      <column name="DOCUMENT_URL" type="VARCHAR(250)">
+      </column>
+      <column name="DOCUMENT_INFO_OWNER" type="VARCHAR(250)">
+      </column>
+      <column name="DOCUMENT_INFO_UPLOADED" type="VARCHAR(250)">
+      </column>
+      <column name="DOCUMENT_INFO_FOLDER" type="VARCHAR(250)">
+      </column>
+      <column name="PERMISSION_ALLOWEDIT" type="BOOLEAN">
+      </column>
+      <column name="EDITOR_CALLBACKURL" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_LANG" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_MODE" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_USER_USERID" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_USER_NAME" type="VARCHAR(250)">
+      </column>
+      <column name="EDITOR_USER_LASTMODIFIED" type="BIGINT">
+      </column>
+      <column name="EDITOR_USER_LASTSAVED" type="BIGINT">
+      </column>
+      <column name="EDITOR_USER_LINKSAVED" type="BIGINT">
+      </column>
+      <column name="EDITOR_USER_DOWNLOAD_LINK" type="VARCHAR(250)">
+      </column>
+    </createTable>
+  </changeSet>
+
+  <changeSet author="onlyoffice" id="1.0.0-2" dbms="oracle,postgresql">
+    <createSequence sequenceName="SEQ_OO_EDITOR_CONFIG_ID" startValue="1"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/services/src/test/resources/conf/test/test-onlyoffice-configuration.xml
+++ b/services/src/test/resources/conf/test/test-onlyoffice-configuration.xml
@@ -6,6 +6,20 @@
 
 
   <component>
+    <key>org.exoplatform.onlyoffice.jpa.EditorConfigDAO</key>
+    <type>org.exoplatform.onlyoffice.jpa.dao.EditorConfigDAOImpl</type>
+  </component>
+
+  <component>
+    <type>org.exoplatform.onlyoffice.jpa.storage.impl.RDBMSEditorConfigStorageImpl</type>
+  </component>
+
+  <component>
+    <key>org.exoplatform.onlyoffice.jpa.EditorConfigStorage</key>
+    <type>org.exoplatform.onlyoffice.jpa.storage.cache.CachedEditorConfigStorage</type>
+  </component>
+
+  <component>
     <key>org.exoplatform.services.cms.documents.DocumentService</key>
     <type>org.exoplatform.onlyoffice.mock.DocumentServiceMock</type>
   </component>

--- a/services/src/test/resources/conf/test/test-organization-configuration.xml
+++ b/services/src/test/resources/conf/test/test-organization-configuration.xml
@@ -337,6 +337,28 @@
                     </field>
                   </object>
                 </value>
+                <value>
+                  <object type="org.exoplatform.services.organization.OrganizationConfig$User">
+                    <field name="userName">
+                      <string>mary</string>
+                    </field>
+                    <field name="password">
+                      <string>gtn</string>
+                    </field>
+                    <field name="firstName">
+                      <string>Mary</string>
+                    </field>
+                    <field name="lastName">
+                      <string>Smith</string>
+                    </field>
+                    <field name="email">
+                      <string>mary@exo.com</string>
+                    </field>
+                    <field name="groups">
+                      <string>member:/platform/users</string>
+                    </field>
+                  </object>
+                </value>
               </collection>
             </field>
           </object>


### PR DESCRIPTION
Before this fix, if a user have an editor page opened, and when exo restarts, modification are losts.
This fix try to improve the robustness of the editor. For that, the cache config is moved in database, so that it is persisted for the restart.
So, when the restart is done, we still have the information of the opened editor