### PR TITLE
Task-52340 : Unable to open onlyoffice editor

### DIFF
--- a/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
+++ b/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
@@ -106,9 +106,7 @@
   </changeSet>
 
   <changeSet author="onlyoffice" id="1.0.0-3">
-    <modifyDataType columnName="EXPLORER_URL"
-                    newDataType="NVARCHAR(1000)"
-                    tableName="OO_EDITOR_CONFIG"/>
+    <modifyDataType columnName="EXPLORER_URL" newDataType="NVARCHAR(1000)" tableName="OO_EDITOR_CONFIG"/>
   </changeSet>
 
 </databaseChangeLog>

--- a/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
+++ b/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
@@ -105,4 +105,10 @@
     <createSequence sequenceName="SEQ_OO_EDITOR_CONFIG_ID" startValue="1"/>
   </changeSet>
 
+  <changeSet author="onlyoffice" id="1.0.0-3">
+    <modifyDataType columnName="EXPLORER_URL"
+                    newDataType="NVARCHAR(1000)"
+                    tableName="OO_EDITOR_CONFIG"/>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Before this fix, when user open only office editor, the path for the editor url can be longer than the max allowed in the database column
This fix increase the column size