### PR TITLE
Task-52340 : Unable to open onlyoffice - Part 2

### DIFF
--- a/services/src/main/resources/conf/portal/configuration.xml
+++ b/services/src/main/resources/conf/portal/configuration.xml
@@ -19,7 +19,7 @@
     <external-component-plugins>
         <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
         <component-plugin>
-            <name>AppCenterChangeLogsPlugin</name>
+            <name>Only Office ChangeLogsPlugin</name>
             <set-method>addChangeLogsPlugin</set-method>
             <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
             <init-params>

--- a/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
+++ b/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
@@ -109,4 +109,8 @@
     <modifyDataType columnName="EXPLORER_URL" newDataType="NVARCHAR(1000)" tableName="OO_EDITOR_CONFIG"/>
   </changeSet>
 
+  <changeSet author="onlyoffice" id="1.0.0-4">
+    <modifyDataType columnName="EDITOR_PAGE_COMMENT" newDataType="NVARCHAR(2000)" tableName="OO_EDITOR_CONFIG"/>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Before this fix, when a document have a long comment (more than 250 chars), it is impossible to open the onlyoffice editor (load without end).
This is due to the fact that the column EDITOR_PAGE_COMMENT in too short in table OO_EDITOR_CONFIG
This fix increase the size of the column.