### PR TITLE
MAINT-52280: Allow potx file type to be viualized by onlyoffice previewer 

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -2825,6 +2825,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     fileTypes.put("ppsx", TYPE_PRESENTATION);
     fileTypes.put("pps", TYPE_PRESENTATION);
     fileTypes.put("odp", TYPE_PRESENTATION);
+    fileTypes.put("potx", TYPE_PRESENTATION);
   }
 
   /**

--- a/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
@@ -354,6 +354,9 @@
                         <value>
                           <string>application/vnd.openxmlformats-officedocument.presentationml.presentation</string>
                         </value>
+                        <value>
+                          <string>application/vnd.openxmlformats-officedocument.presentationml.template</string>
+                        </value>
                       </collection>
                     </field>
                   </object>


### PR DESCRIPTION

ISSUE: Potx files are not recognized as a presentation files in onlyoffice previewer despite that it's supported by onlyoffice in view mode
FIX: This PR should add the potx mimetype and extension to the onlyoffice previewer service and plugin to visualize it in preview mode