### PR TITLE
Task-53798 : Add the possibility to edit open office document format

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
@@ -154,6 +154,15 @@
                 <value>
                   <string>application/vnd.openxmlformats-officedocument.wordprocessingml.document</string>
                 </value>
+                <value>
+                  <string>application/vnd.oasis.opendocument.text</string>
+                </value>
+                <value>
+                  <string>application/vnd.oasis.opendocument.spreadsheet</string>
+                </value>
+                <value>
+                  <string>application/vnd.oasis.opendocument.presentation</string>
+                </value>
               </collection>
             </field>
           </object>


### PR DESCRIPTION
Before this fix, edit button in file explorer was not present for OpenOffice format (ods,odt,odp)
This commit add the mimetypes for OpenOffice format, so that, the edit button is now present