### PR TITLE
TASK-53813: Add support (view and edit) for docxf and oform file types with onlyoffice

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -2815,6 +2815,8 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     fileTypes.put("pdf", TYPE_TEXT);
     fileTypes.put("djvu", TYPE_TEXT);
     fileTypes.put("xps", TYPE_TEXT);
+    fileTypes.put("docxf", TYPE_TEXT);
+    fileTypes.put("oform", TYPE_TEXT);
     // Speadsheet formats
     fileTypes.put("xlsx", TYPE_SPREADSHEET);
     fileTypes.put("xls", TYPE_SPREADSHEET);

--- a/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
@@ -154,6 +154,9 @@
                 <value>
                   <string>application/vnd.openxmlformats-officedocument.wordprocessingml.document</string>
                 </value>
+                <value>
+                  <string>application/vnd.openxmlformats-officedocument.wordprocessingml.document.form</string>
+                </value>
               </collection>
             </field>
           </object>
@@ -356,6 +359,9 @@
                         </value>
                         <value>
                           <string>application/vnd.openxmlformats-officedocument.presentationml.template</string>
+                        </value>
+                        <value>
+                          <string>application/vnd.openxmlformats-officedocument.wordprocessingml.document.form</string>
                         </value>
                       </collection>
                     </field>


### PR DESCRIPTION
Prior to this change, docxf and oform types are not supported with our onlyoffice integration. This PR should make the onlyoffice able to view and edit these types of files by adding their mimetypes to be recognized by OO