### PR TITLE
Task-52972: Document: It is no longer possible to open a document in full screen

### DIFF
--- a/webapp/src/main/java/org/exoplatform/onlyoffice/portlet/EditorPortlet.java
+++ b/webapp/src/main/java/org/exoplatform/onlyoffice/portlet/EditorPortlet.java
@@ -89,7 +89,7 @@ public class EditorPortlet extends GenericPortlet {
                                                             "locale.onlyoffice.OnlyofficeClient" },
                                                         request.getLocale());
 
-    Config config = getConfig(request, response, i18n, OnlyofficeEditorService.EDIT_MODE);
+    Config config = getConfig(request, response, i18n, OnlyofficeEditorService.VIEW_MODE);
 
     if (config != null) {
       Element onlyOfficeJavascript = response.createElement("script");

--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -500,6 +500,7 @@
         config.height = "100%";
         config.width = "100%";
         config.editorConfig.embedded = {
+          fullscreenUrl: config.editorUrl,
           saveUrl: config.downloadUrl,
           toolbarDocked: "top"
         };


### PR DESCRIPTION


Problems:
1- when it is an onlyoffice document, it is no longer possible to open a document in full screen even if you have read and edit rights, which blocks reading and searching.
2-Even if you add full screen button, there is still a problem which is that when the user has read only permission .He cannot open the document in mode full screen view and an error "Error creating document editor" is appeared
Fixes:
1-In first fix, we've added this embedded config to editor configuration and so  this full screen button will be always shown Among other options.
2-For the second problem, we've changed the mode in the configuration to VIEW_MODE because it is the default one used when the user clicks on the full-screen button. the mode was EDIT_MODE and that's why the method OnlyOffice.createEditor() will be called instead of createViewer(). And when checking in the permission of the user.it finds that he has no right to edit the file finally the OnlyofficeEditorException is thrown.