### PR TITLE
TASK-57017: Allow view PDF files with onlyoffice

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/onlyoffice/configuration.xml
@@ -379,6 +379,9 @@
                         <value>
                           <string>application/vnd.openxmlformats-officedocument.wordprocessingml.document.form</string>
                         </value>
+                        <value>
+                          <string>application/pdf</string>
+                        </value>
                       </collection>
                     </field>
                   </object>


### PR DESCRIPTION
Prior to this change, Pdf files mimtype wasn't yet recognized by onlyoffice File viewer plugin.
This PR adds the PDF standard mimtype to allow it to be recognized by onlyoffice fileviewer plugin and so view pdf files by onlyoffice instead on pdf.js as it has less priority