### PR TITLE
TASK-56789: Add supported documents extension

### DIFF
--- a/webapp/src/main/webapp/js/extension.js
+++ b/webapp/src/main/webapp/js/extension.js
@@ -28,10 +28,58 @@
       color: '#CB4B32',
     }
   ];
+  const supportedDocumentsExtensionOptions = [
+    {
+      provider: 'onlyoffice',
+      extension: '.docx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      view: true,
+      edit: true
+    },
+    {
+      provider: 'onlyoffice',
+      extension: '.docxf',
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      view: true,
+      edit: true
+    },
+    {
+      provider: 'onlyoffice',
+      extension: '.pptx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      view: true,
+      edit: true
+    },
+    {
+      provider: 'onlyoffice',
+      extension: '.xlsx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      view: true,
+      edit: true
+    },
+    {
+      provider: 'onlyoffice',
+      extension: '.oform',
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.form',
+      view: true,
+      edit: true
+    },
+    {
+      provider: 'onlyoffice',
+      extension: '.pdf',
+      mimeType: 'application/pdf',
+      view: true,
+      edit: false
+    },
+  ];
+
   const lang = eXo.env.portal.language || 'en';
   const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.navigation.portal.global-${lang}.json`;
 
   exoi18n.loadLanguageAsync(lang, url).then(i18n => new Vue({i18n}));
   newDocumentTypeExtensionOptions.forEach(extension => extensionRegistry.registerExtension('attachment', 'new-document-action', extension));
   document.dispatchEvent(new CustomEvent('attachment-new-document-action-updated'));
+
+  supportedDocumentsExtensionOptions.forEach(extension => extensionRegistry.registerExtension('documents', 'supported-document-types', extension));
+  document.dispatchEvent(new CustomEvent('documents-supported-document-types-updated'));
 })();


### PR DESCRIPTION
Prior to this change, No good way was already exist to handle supported docs by onlyoffice outside of the addon.
This PR should add an extension for actual  supported documents in edit and view mode by onlyoffice to allow better management of these types in documents app