### PR TITLE
TASK-57905 fix the encoding special characters included in the document name and displayed in toolbar in onlyoffice

### DIFF
--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -584,6 +584,7 @@
         createViewer(config).done(function(localConfig) {
           if (localConfig) {
             currentConfig = localConfig;
+            currentConfig.document.title = decodeURI(decodeURI(currentConfig.document.title));
             $(function() {
               try {
                 new DocsAPI.DocEditor("onlyoffice", localConfig);


### PR DESCRIPTION
Problem: the parameter `document.title` in the config for onlyoffice was retrieved from backend with encoding special characters included in document name and it was displayed like it is when user preview the document.
Fix: decode special characters included in the title of the document  previously was encoded twice.