### PR TITLE
fix: Fix previewing a shared document by its copied link - EXO-58927

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -60,6 +60,7 @@ import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 import javax.jcr.lock.Lock;
@@ -2305,8 +2306,8 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
    */
   protected Node nodeByUUID(String workspace, String uuid) throws RepositoryException {
     SessionProvider sp = sessionProviders.getSessionProvider(null);
-    Session userSession = sp.getSession(workspace, jcrService.getCurrentRepository());
-    return userSession.getNodeByUUID(uuid);
+    ExtendedSession userSession = (ExtendedSession) sp.getSession(workspace, jcrService.getCurrentRepository());
+    return userSession.getNodeByIdentifier(uuid);
   }
 
   /**


### PR DESCRIPTION

Prior to this change, we are not able to preview a shared document by its copied link since it is not possible to retrieve to corresponding symlink node using session.getNodeByUUID(). To fix that, we use extendedSession.getNodeByIdentifier in order to retrieve correctly the symlink node and preview it correctly.