### PR TITLE
fix: Avoid creating two versions of a document at first edit by onlyoffice - EXO-59882

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -2025,17 +2025,6 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
           modifierConfig.setSameModifier(sameModifier);
           modifierConfig.setPreviousModified(content.getProperty("jcr:lastModified").getDate());
 
-          Boolean onlyofficeVersion = false;
-          if (frozen.hasProperty("eoo:onlyofficeVersion")) {
-            onlyofficeVersion = frozen.getProperty("eoo:onlyofficeVersion").getBoolean();
-          }
-          Calendar lastModified = node.getProperty("exo:lastModifiedDate").getDate();
-          Calendar versionDate = frozen.getProperty("exo:lastModifiedDate").getDate();
-          // Create a version of the manually uploaded draft if exists
-          if (versionDate.getTimeInMillis() <= lastModified.getTimeInMillis() && !onlyofficeVersion) {
-            createVersionOfDraft(node);
-          }
-
           content.setProperty("jcr:lastModified", editedTime);
           if (content.hasProperty("exo:dateModified")) {
             content.setProperty("exo:dateModified", editedTime);

--- a/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
+++ b/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
@@ -1356,20 +1356,14 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
 
     // Then
     assertNotNull(versions);
-    assertEquals(2, versions.size());
+    assertEquals(1, versions.size());
     Version version1 = versions.get(0);
     assertEquals("john", version1.getAuthor());
     assertEquals(1, version1.getVersionPageNumber());
     assertEquals("John Anthony", version1.getFullName());
     assertNotNull(version1.getVersionLabels());
-    assertEquals(0, version1.getVersionLabels().length);
-    Version version2 = versions.get(1);
-    assertEquals("john", version2.getAuthor());
-    assertEquals("John Anthony", version2.getFullName());
-    assertNotNull(version2.getVersionLabels());
-    assertEquals(1, version2.getVersionLabels().length);
-    assertEquals("Document updated", version2.getVersionLabels()[0]);
-
+    assertEquals(1, version1.getVersionLabels().length);
+    assertEquals("Document updated", version1.getVersionLabels()[0]);
     node.remove();
   }
 


### PR DESCRIPTION

Prior to this change, when edit a document at first time onlyoffice creates two versions, the first only after checking that there no onlyoffice created version for the document, and in the same function it creates a second version after setting onlyoffice mixin properties.