### PR TITLE
feat: UPDATE OnlyOffice api.js URL -EXO-59424

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -474,7 +474,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     documentserverUrl.append(dsHost);
 
     this.uploadUrl = new StringBuilder(documentserverUrl).append("/FileUploader.ashx").toString();
-    this.documentserverUrl = new StringBuilder(documentserverUrl).append("/OfficeWeb/").toString();
+    this.documentserverUrl = new StringBuilder(documentserverUrl).append("/web-apps/").toString();
     this.commandServiceUrl = new StringBuilder(documentserverUrl).append("/coauthoring/CommandService.ashx").toString();
     this.documentserverAccessOnly = Boolean.parseBoolean(config.get(CONFIG_DS_ACCESS_ONLY));
     this.documentserverSecret = config.get(CONFIG_DS_SECRET);


### PR DESCRIPTION
According to the change made by `onlyoffice` for their Document Server, the path to the JavaScript API file has been changed from version 7.0 . 
To add this, change `documentserverUrl` from `OfficeWeb` to web-app.
After this change, avoid redirects The URL `https://documentserver/OfficeWeb/apps/api/documents/api.js` to `https://documentserver/web-apps/apps/api/documents/api.js` .