### PR TITLE
fix: In some cases, OO was not able to open the document as it use the path to open it - EXO-62901

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -845,7 +845,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
             throw new OnlyofficeEditorException("Cannot set conversation state " + userId);
           }
           // work in user session
-          Node node = node(config.getWorkspace(), config.getPath());
+          Node node = nodeByUUID(config.getWorkspace(), config.getDocId());
 
           if (viewMode) {
             viewerCache.remove(key);


### PR DESCRIPTION
When renaming or moving a file, and edit it, in some case, OO continue to use old config object, containing the old path of the document As the document have moved, OO was not able to download the document content This fix modify how we get the document, by getting it by node uuid, which never change. So even if the document is rename, and an old config is used, we are able to edit the document.