### PR TITLE
feat: introduce eXo parent pom - EXO-64103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>addons-parent-pom</artifactId>
+    <artifactId>addons-parent-exo-pom</artifactId>
     <groupId>org.exoplatform.addons</groupId>
-    <version>17-exo-M01</version>
+    <version>17-security-fix-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo-onlyoffice-editor-parent</artifactId>
@@ -44,7 +44,6 @@
 
   <properties>
     <!-- eXo Modules -->
-    <org.exoplatform.social.version>6.5.x-exo-SNAPSHOT</org.exoplatform.social.version>
     <addon.exo.ecms.version>6.5.x-SNAPSHOT</addon.exo.ecms.version>
   
     <!-- Sonar properties -->
@@ -53,14 +52,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Import versions from platform projects -->
-      <dependency>
-        <groupId>org.exoplatform.social</groupId>
-        <artifactId>social</artifactId>
-        <version>${org.exoplatform.social.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.exoplatform.ecms</groupId>
         <artifactId>ecms</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>addons-parent-exo-pom</artifactId>
+    <artifactId>addons-exo-parent-pom</artifactId>
     <groupId>org.exoplatform.addons</groupId>
     <version>17-security-fix-SNAPSHOT</version>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>addons-exo-parent-pom</artifactId>
     <groupId>org.exoplatform.addons</groupId>
-    <version>17-security-fix-SNAPSHOT</version>
+    <version>17-M01</version>
   </parent>
 
   <artifactId>exo-onlyoffice-editor-parent</artifactId>


### PR DESCRIPTION
This feature introduce new parent pom for eXo to be able to declare libraries versions used only in eXo, without impacting meeds