### PR TITLE
fix: don't prevent other users from saving new versions even if they have not added changes - EXO-64990

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
@@ -384,5 +384,10 @@ public interface OnlyofficeEditorService {
 
   void closeWithoutModification(String userId, String key);
 
+  /**
+   * Checks if the document is opened for edition by multiple users
+   * @param key Document key
+   * @return Boolean true if the document is opened for edition by multiple users
+   */
   boolean isDocumentCoedited(String key);
 }

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
@@ -383,4 +383,6 @@ public interface OnlyofficeEditorService {
   String getDocumentServiceSecret();
 
   void closeWithoutModification(String userId, String key);
+
+  boolean isDocumentCoedited(String key);
 }

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -1608,6 +1608,12 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     }
   }
 
+  @Override
+  public boolean isDocumentCoedited(String key) {
+    Map<String, Config> configs = cachedEditorConfigStorage.getConfigsByKey(key);
+    return configs != null && !configs.isEmpty() && configs.size() > 1;
+  }
+
   /**
    * Save link.
    *

--- a/services/src/main/java/org/exoplatform/onlyoffice/cometd/CometdOnlyofficeService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/cometd/CometdOnlyofficeService.java
@@ -655,7 +655,7 @@ public class CometdOnlyofficeService implements Startable {
       // If there were changes after last saving
       if (lastModifier != null && lastModifier.getLastModified() > lastModifier.getLastSaved()) {
         // If there is relevant link
-        if (lastModifier.getLinkSaved() >= lastModifier.getLastModified()) {
+        if (lastModifier.getLinkSaved() >= lastModifier.getLastModified() || editors.isDocumentCoedited(key)) {
           editors.downloadVersion(userId, key, true, true, comment, lastModifier.getDownloadLink());
         } else {
           editors.forceSave(userId, key, true, false, true, comment);


### PR DESCRIPTION
When a collaborator tries to save twice a new version of a document, it does not always check if the document is co-edited and will try to save his changes in the second try. This causes receiving a success operation popup but the document is not saved again and no v ersion is created.
This fix checks correctly if the document is coedited before calling the save of the document to ensure it gets all changes done by all collaborators.