### PR TITLE
fix: When a version is created by system, the version history drawer is empty - EXO-65435

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -1179,7 +1179,12 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       version.setAuthor(versionNode.getAuthor());
       version.setName(versionNode.getName());
       version.setDisplayName(versionNode.getDisplayName());
-      version.setFullName(getUser(versionNode.getAuthor()).getDisplayName());
+      String displayName = versionNode.getAuthor();
+      User versionAuthor = getUser(versionNode.getAuthor());
+      if (versionAuthor != null) {
+        displayName = versionAuthor.getDisplayName();
+      }
+      version.setFullName(displayName);
       version.setVersionLabels(versionNode.getVersionLabels());
       version.setCreatedTime(versionNode.getCreatedTime().getTimeInMillis());
       version.setVersionPageNumber(pageNbrs);


### PR DESCRIPTION
Before this fix, when a version is created by system session (by a job for example), the version history drawer is empty due to error in RestService : when computing user profile, the identity for system is not found, and so getting the profile create a null pointer exception This fix adress this special case to not have the NPE