### PR TITLE
fix: set correctly the Onlyoffice editor language - EXO-64615

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -2476,7 +2476,12 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     String lang = Locale.getDefault().getLanguage();
     if(localePolicy != null) {
       Locale locale = localePolicy.determineLocale(localeCtx);
-      lang = locale.getLanguage() + "-" + locale.getCountry();
+      lang = locale.getLanguage();
+      // In case of pt_PT or cn_TW we have to add the country
+      // as detailed in https://api.onlyoffice.com/editors/config/editor#lang
+      if("PT".equalsIgnoreCase(locale.getCountry()) || "TW".equalsIgnoreCase(locale.getCountry())) {
+        lang = locale.getLanguage() + "-" + locale.getCountry();
+      }
     }
     return lang;
   }


### PR DESCRIPTION
The property lang was holding a wrong value of the language like **en-** or **fr-** which was not interpreted correctly by the onlyoffice editor and the language was always set to Enlish and Aerbidjan country (defaults)
The fix returns just the language (without the country variant), it adds the country language just for Taiwan chinese and Portugal portuguese as detailed in documentation https://api.onlyoffice.com/editors/config/editor#lang