### PR TITLE
fix : Enable to download document containing apostrophe from action menu of preview mode - EXO-66214 (#210)

### DIFF
--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -579,6 +579,7 @@
      */
     this.initEmbeddedViewer = function(config) {
       if (config) {
+        config.downloadUrl = config.downloadUrl.replaceAll("%", "%25");
         log("Initialize viewer for document: " + config.docId);
         log("i18n: " + JSON.stringify(messages));
         createViewer(config).done(function(localConfig) {


### PR DESCRIPTION
This change will encode the download URL of the file to enable downloading from the preview mode actions menu