### PR TITLE
fix: Enable to edit file with name created using unicodes - EXO-67738

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/impl/RDBMSEditorConfigStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/impl/RDBMSEditorConfigStorageImpl.java
@@ -10,6 +10,9 @@ import org.exoplatform.onlyoffice.jpa.EditorConfigStorage;
 import org.exoplatform.onlyoffice.jpa.entities.EditorConfigEntity;
 
 
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -102,7 +105,13 @@ public class RDBMSEditorConfigStorageImpl implements EditorConfigStorage {
     result.setClosedTime(config.getClosedTime());
     result.setEditorPageLastModifier(config.getEditorPage().getLastModifier());
     result.setEditorPageLastModified(config.getEditorPage().getLastModified());
-    result.setEditorPageDisplayPath(config.getEditorPage().getDisplayPath());
+    String encodedDisplayPath;
+    try {
+      encodedDisplayPath = URLEncoder.encode(config.getEditorPage().getDisplayPath(), StandardCharsets.UTF_8);
+    } catch (Exception exception) {
+      encodedDisplayPath = null;
+    }
+    result.setEditorPageDisplayPath(encodedDisplayPath != null ? encodedDisplayPath : config.getEditorPage().getDisplayPath());
     result.setEditorPageComment(config.getEditorPage().getComment());
     result.setEditorPageDrive(config.getEditorPage().getDrive());
     result.setEditorPageRenamedAllowed(config.getEditorPage().getRenameAllowed());
@@ -138,7 +147,13 @@ public class RDBMSEditorConfigStorageImpl implements EditorConfigStorage {
     builder.owner(entity.getEditorUserUserid());
     builder.fileType(entity.getDocumentFileType());
     builder.uploaded(entity.getDocumentInfoUploaded());
-    builder.displayPath(entity.getEditorPageDisplayPath());
+    String decodedDisplayPath;
+    try {
+      decodedDisplayPath = URLDecoder.decode(entity.getEditorPageDisplayPath(), StandardCharsets.UTF_8);
+    } catch (Exception exception) {
+      decodedDisplayPath = null;
+    }
+    builder.displayPath(decodedDisplayPath != null ? decodedDisplayPath :entity.getEditorPageDisplayPath());
     builder.comment(entity.getEditorPageComment());
     builder.drive(entity.getEditorPageDrive());
     builder.renameAllowed(entity.isEditorPageRenamedAllowed());

--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -1116,11 +1116,11 @@
       if (drive.startsWith('spaces/')) {
         var folders = config.editorPage.displayPath.split(':')[1].split('/');
         var title = folders.pop();
-        var titleWithoutAccent = this.removeAccents(title);
         var spaceName = drive.split('spaces/')[1];
         var spaceNameWithoutAccent = this.removeAccents(spaceName);
         var newDrivePath = spaceNameWithoutAccent.replace(/\ /g, '_').toLowerCase();
-        var pathDocument = config.path.split(newDrivePath + '/')[1].split("/" + titleWithoutAccent)[0];
+        var pathDocument = config.path.split(newDrivePath + '/')[1];
+        pathDocument = pathDocument.substring(0, pathDocument.lastIndexOf('/'))
         var pathDocumentWithIcon = pathDocument.replace(/\//g, function() {
           return "<i class='uiIconArrowRight'></i>";
         });


### PR DESCRIPTION
Prior to this change, when attempting to edit a document with a name created using Unicode, the only office editor would not open, and an SQL exception was thrown. This issue arose from the string format of the value of the EDITOR_PAGE_DISPLAY_PATH, which is used to display the breadcrumb and the title of the document on the editor drawer.
With this change, the EDITOR_PAGE_DISPLAY_PATH property value will be encoded before saving it and decoded when retrieved.