### PR TITLE
fix: some events in webconferencing are not correctly configured - EXO-70693

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.exoplatform.ecms</groupId>
       <artifactId>ecms-core-webui</artifactId>
-      <scope>provided</scope>
+      <scope>compile</scope>
     </dependency>
         <dependency>
       <groupId>org.exoplatform.ecms</groupId>

--- a/services/src/main/java/org/exoplatform/onlyoffice/cometd/CometdOnlyofficeService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/cometd/CometdOnlyofficeService.java
@@ -30,8 +30,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
 import javax.jcr.Item;
 import javax.jcr.Node;
 import javax.jcr.Property;


### PR DESCRIPTION
Before this fix,  some listener not correctly added when CometOnlyService starts : This listeners are added in postConstruct method, which is no more call, because the used annotation is the old javax.annotation.PostConstruct.

This commit update the annotion to use jakarta.annotation.PostConstruct. It also change PreDestroy and Inject annotations