### PR TITLE
fix: Hide shared layout on OO Editor page - EXO-72989

### DIFF
--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -1041,10 +1041,6 @@
      * Init editor page UI.
      */
     this.initEditor = function() {
-      // We don't need this (thx to OnlyofficeEditorLifecycle)
-      // $("#NavigationPortlet").remove();
-      // But we may need this for some cases of first page loading
-      $("#LeftNavigation").parent(".LeftNavigationTDContainer").remove();
       // Specific styles to add to hide/fix portal layout
       // We prefer to add to an element with already applied Platform skin style
       var $body = $("#UIWorkingWorkspace");


### PR DESCRIPTION
This commit removes unecessary code to hide left menu as shared layout is no more displayed