### PR TITLE
fix: Redirect should be to related to current page after editing attachment - EXO-71706

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/Config.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/Config.java
@@ -1104,6 +1104,9 @@ public class Config implements Externalizable {
   /**  The close timestamp. */
   private Long                            closedTime;
 
+  /**  The back to path. */
+  private String backTo;
+
   /**
    * Instantiates a new config for use with {@link Externalizable} methods. User
    * by serialization.
@@ -1522,6 +1525,25 @@ public class Config implements Externalizable {
    */
   public Boolean getSameModifier() {
     return this.sameModifier.get();
+  }
+
+
+  /**
+   * Gets the backTo.
+   *
+   * @return the backTo
+   */
+  public String getBackTo() {
+    return backTo;
+  }
+
+  /**
+   * Sets the backTo.
+   *
+   * @param backTo the backTo
+   */
+  public void setBackTo(String backTo) {
+    this.backTo = backTo;
   }
 
   /**

--- a/webapp/src/main/java/org/exoplatform/onlyoffice/portlet/EditorPortlet.java
+++ b/webapp/src/main/java/org/exoplatform/onlyoffice/portlet/EditorPortlet.java
@@ -155,6 +155,7 @@ public class EditorPortlet extends GenericPortlet {
 
     RequestContext requestContext = RequestContext.getCurrentInstance();
     String docId = requestContext.getRequestParameter("docId");
+    String backTo = requestContext.getRequestParameter("backTo");
 
     if (docId != null) {
       try {
@@ -182,6 +183,9 @@ public class EditorPortlet extends GenericPortlet {
               // Otherwise use system default one
               config.getEditorConfig().setLang(Locale.getDefault().getLanguage());
             }
+          }
+          if (backTo != null) {
+            config.setBackTo(backTo);
           }
         } else {
           showError(i18n.getString("OnlyofficeEditorClient.ErrorTitle"),

--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -535,7 +535,7 @@
           "goback": {
             "blank": true,
             "text": message("GoToDocument"),
-            "url": config.explorerUrl
+            "url":  config.backTo ? `${window.location.origin}${config.backTo}` : config.explorerUrl
           },
           "help": true,
           "logo": {

--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -535,7 +535,7 @@
           "goback": {
             "blank": true,
             "text": message("GoToDocument"),
-            "url":  config.backTo ? `${window.location.origin}${config.backTo}` : config.explorerUrl
+            "url":  getBackUrl(config)
           },
           "help": true,
           "logo": {
@@ -569,6 +569,18 @@
       }
       return process.promise();
     };
+    /**
+     * Create back button url.
+     */
+      var getBackUrl = function(config) {
+      if(!config.backTo){
+        return config.explorerUrl;
+      }
+      const url = new URL(`${window.location.origin}${config.backTo}`);
+      url.searchParams.set('updated', changesSaved);
+      return url.toString();
+    };
+
     this.createEditor = createEditor;
     this.createViewer = createViewer;
 


### PR DESCRIPTION
Before this fix, after editing a document, the back button always opens the location of the document in the document app.
Since a document can be edited from different locations (process, task, activity, etc.), the back button should open the location where the edit was requested. this fix adds a new path param whith the go back location to be opened when clicking on the back button on the oo editor