### PR TITLE
fix: new post of a user not member in who can manage space is generated because of new version - EXO-72993

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -2263,14 +2263,6 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
               LOG.debug("Node final save (Node (id={},path={}), userId={})",
                         node.getUUID(), node.getPath(), userId);
             }
-            // If the status code == 2, the EDITOR_SAVED_EVENT should be thrown.
-            if (statusCode != 2) {
-              if(LOG.isDebugEnabled()) {
-                LOG.debug("Broacast EDITOR_VERSION_EVENT (Node (id={},path={}), userId={})",
-                          node.getUUID(), node.getPath(), userId);
-              }
-              broadcastEvent(status, OnlyofficeEditorService.EDITOR_VERSION_EVENT);
-            }
           }
 
           fireSaved(status);


### PR DESCRIPTION
Before this fix every time a user creates a new version using only office, an activity is created even from user that is nor member f the space. this fix remove this kind of activities.