### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
+++ b/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
@@ -106,11 +106,13 @@
   </changeSet>
 
   <changeSet author="onlyoffice" id="1.0.0-3">
-    <modifyDataType columnName="EXPLORER_URL" newDataType="NVARCHAR(1000)" tableName="OO_EDITOR_CONFIG"/>
+    <validCheckSum>9:07e6f19c40fb8b6d4cae8d4499483cad</validCheckSum>
+    <modifyDataType columnName="EXPLORER_URL" newDataType="VARCHAR(1000)" tableName="OO_EDITOR_CONFIG"/>
   </changeSet>
 
   <changeSet author="onlyoffice" id="1.0.0-4">
-    <modifyDataType columnName="EDITOR_PAGE_COMMENT" newDataType="NVARCHAR(2000)" tableName="OO_EDITOR_CONFIG"/>
+    <validCheckSum>9:7559179db190cb8464a0489db3840544</validCheckSum>
+    <modifyDataType columnName="EDITOR_PAGE_COMMENT" newDataType="VARCHAR(2000)" tableName="OO_EDITOR_CONFIG"/>
   </changeSet>
 
   <changeSet author="onlyoffice" id="1.0.0-5" dbms="hsqldb">


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR.
This commit adapt liquibase changes in order to apply this change.