### PR TITLE
fix: unable to use OO 8.2 with arabic language - EXO-76393

### DIFF
--- a/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
+++ b/services/src/main/resources/db.changelogs/onlyoffice-changelog-1.0.0.xml
@@ -120,4 +120,8 @@
     <sql>ALTER TABLE OO_EDITOR_CONFIG MODIFY COLUMN DOCUMENT_TITLE varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;</sql>
   </changeSet>
 
+  <changeSet id="1.0.0-7" author="onlyoffice" dbms="mysql">
+    <sql>ALTER TABLE OO_EDITOR_CONFIG MODIFY COLUMN EDITOR_PAGE_LAST_MODIFIED varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;</sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Before this fix, when the platform is configured in arabic we are unable to open OO for a document This is due to collation problem on column EDITOR_PAGE_LAST_MODIFIED : OO send last modidied date in arabic, which cannot be store with latin1 charset

This commit update the charset for this column