### PR TITLE
fix: eXIP10_US02.02: View openoffice documents in onlyoffice - EXO-78232

### DIFF
--- a/webapp/src/main/webapp/js/extension.js
+++ b/webapp/src/main/webapp/js/extension.js
@@ -92,6 +92,27 @@
       view: true,
       edit: false
     },
+    {
+      provider: 'onlyoffice',
+      extension: '.ods',
+      mimeType: 'application/vnd.oasis.opendocument.spreadsheet',
+      view: true,
+      edit: false
+    },
+    {
+      provider: 'onlyoffice',
+      extension: '.odt',
+      mimeType: 'application/vnd.oasis.opendocument.text',
+      view: true,
+      edit: false
+    },
+    {
+      provider: 'onlyoffice',
+      extension: '.odp',
+      mimeType: 'application/vnd.oasis.opendocument.presentation',
+      view: true,
+      edit: false
+    },
   ];
 
   const lang = eXo.env.portal.language || 'en';


### PR DESCRIPTION
Before this fix .ods, .odt, .odp files are nor opened in onlyoffice. this fix will add these types of files to supported viewable files by onlyofficce.