### PR TITLE
fix: Attached pdf documents can't be downloaded not located - EXO-79491

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/Config.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/Config.java
@@ -669,7 +669,7 @@ public class Config implements Externalizable {
        * Instantiates a new views the permissions.
        */
       protected FillFormPermissions() {
-        super(false, false,false,true );
+        super(true, false,false,true );
       }
     }
 


### PR DESCRIPTION
Before this change, when userX creates request on processA and attach pdf and xlsx then processAdmin get request, display attachment drawer and click on both attached documents, pdf documents can't be downloaded as no option available. To fix this problem, change the value of download from false to true when the mode is fillform. After this change, pdf documents can't be downloaded as no option available.