### PR TITLE
fix: Add placeholder page when the user accesses another user's personal drive - EXO-82012

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/Config.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/Config.java
@@ -143,9 +143,9 @@ public class Config implements Externalizable {
     // Editor.User
     protected String       userId, name;
     
+    protected boolean      canAccess;
   
-  
-    protected boolean allowEdition = true;
+    protected boolean      allowEdition = true;
 
     /**
      * Instantiates a new builder.
@@ -433,6 +433,17 @@ public class Config implements Externalizable {
     }
 
     /**
+     * Sets can access document path or not.
+     *
+     * @param canAccess the access document path
+     * @return the builder
+     */
+    public Builder canAccess(boolean canAccess) {
+      this.canAccess = canAccess;
+      return this;
+    }
+
+    /**
      * Download url.
      *
      * @param downloadUrl the download url
@@ -485,6 +496,7 @@ public class Config implements Externalizable {
       Document document = new Document(key, fileType, title, url, info, permissions);
       Editor.User user = new Editor.User(userId, name);
       Editor editor = new Editor(callbackUrl, lang, mode, user);
+      editor.setCanAccess(this.canAccess);
       EditorPage editorPage = new EditorPage(comment, renameAllowed, displayPath, lastModifier, lastModified,drive);
       Config config = new Config(documentserverUrl,
                                  platformRestUrl,
@@ -921,6 +933,8 @@ public class Config implements Externalizable {
     /** The mode. */
     protected String       mode;
 
+    protected boolean      canAccess;
+
     /**
      * Instantiates a new editor.
      *
@@ -935,6 +949,25 @@ public class Config implements Externalizable {
       this.lang = lang;
       this.mode = mode != null && mode.equals("fillform") ? "edit" : mode;
       this.user = user;
+    }
+
+    /**
+     * Sets if can access to document path.
+     *
+     * @param canAccess the can access variable
+     */
+    public void setCanAccess(boolean canAccess) {
+      this.canAccess = canAccess;
+    }
+
+
+    /**
+     * Is canAccess.
+     *
+     * @return the isCanAccess
+     */
+    public Boolean isCanAccess() {
+      return canAccess;
     }
 
     /**

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -820,6 +820,12 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       builder.setAllowEdition(false);
     }
 
+    boolean canAccessDocument = false;
+    if (path.startsWith(usersPath)) {
+      canAccessDocument = canEditDocument(node);
+    }
+    builder.canAccess(canAccessDocument);
+
     Config config = builder.build();
     // Create users' config map and add first user
     ConcurrentHashMap<String, Config> configs = new ConcurrentHashMap<>();

--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -577,7 +577,7 @@
      * Create back button url.
      */
       var getBackUrl = function(config) {
-      if (config.editorConfig && config.editorConfig.canAccess === false) {
+      if (config.editorConfig && !config.editorConfig.canAccess) {
         const url = new URL(window.location.origin + eXo.env.portal.context + "/" + eXo.env.portal.portalName + "/restricted-drive");
         return url.toString();
       }

--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -577,6 +577,10 @@
      * Create back button url.
      */
       var getBackUrl = function(config) {
+      if (config.editorConfig && config.editorConfig.canAccess === false) {
+        const url = new URL(window.location.origin + eXo.env.portal.context + "/" + eXo.env.portal.portalName + "/restricted-drive");
+        return url.toString();
+      }
       if(!config.backTo){
         return config.explorerUrl;
       }


### PR DESCRIPTION
Before this change, a user creates a document in his personal drive, then attaches it to an article in a space. Another user who is a member of the same space goes to the location of the first user's document, which is restricted because it is located in his personal drive. This change corrects this behavior and displays a placeholder page to the second user to indicate that he does not have access to this drive.