### PR TITLE
fix: Add placeholder page when the user accesses another user's personal drive - EXO-82012

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -728,6 +728,9 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       config.getEditorPage().setComment(nodeComment(node));
       config.getEditorPage().setLastModifier(getLastModifier(node));
       config.getEditorPage().setLastModified(getLastModified(node));
+      if (path.startsWith(usersPath)) {
+        config.getEditorConfig().setCanAccess(canEditDocument(node));
+      }
 
       cachedEditorConfigStorage.saveConfig(config.getDocument().getKey(), config,false);
       cachedEditorConfigStorage.saveConfig(config.getDocId(),config,false);


### PR DESCRIPTION
Before this change, a user creates a document in his personal drive, then attaches it to an article in a space. Another user who is a member of the same space goes, by clicking on 'go to document' button, to the placeholder page and sees that he cannot access the document location, but the author of the document is also redirected to this page, which is incorrect, as the author should be redirected to his personal drive.
 This change corrects this behavior by setting the canAccess variable to the default value true and modifying it when necessary, when another user cannot access the document location.