### PR TITLE
fix: Add placeholder page when the user accesses another user's personal drive - EXO-82012

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/Config.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/Config.java
@@ -143,7 +143,7 @@ public class Config implements Externalizable {
     // Editor.User
     protected String       userId, name;
     
-    protected boolean      canAccess;
+    protected boolean      canAccessDocumentLocation;
   
     protected boolean      allowEdition = true;
 
@@ -438,8 +438,8 @@ public class Config implements Externalizable {
      * @param canAccess the access document path
      * @return the builder
      */
-    public Builder canAccess(boolean canAccess) {
-      this.canAccess = canAccess;
+    public Builder canAccessDocumentLocation(boolean canAccess) {
+      this.canAccessDocumentLocation = canAccess;
       return this;
     }
 
@@ -496,7 +496,7 @@ public class Config implements Externalizable {
       Document document = new Document(key, fileType, title, url, info, permissions);
       Editor.User user = new Editor.User(userId, name);
       Editor editor = new Editor(callbackUrl, lang, mode, user);
-      editor.setCanAccess(this.canAccess);
+      editor.setCanAccessDocumentLocation(this.canAccessDocumentLocation);
       EditorPage editorPage = new EditorPage(comment, renameAllowed, displayPath, lastModifier, lastModified,drive);
       Config config = new Config(documentserverUrl,
                                  platformRestUrl,
@@ -933,7 +933,7 @@ public class Config implements Externalizable {
     /** The mode. */
     protected String       mode;
 
-    protected boolean      canAccess;
+    protected boolean      canAccessDocumentLocation;
 
     /**
      * Instantiates a new editor.
@@ -956,18 +956,18 @@ public class Config implements Externalizable {
      *
      * @param canAccess the can access variable
      */
-    public void setCanAccess(boolean canAccess) {
-      this.canAccess = canAccess;
+    public void setCanAccessDocumentLocation(boolean canAccess) {
+      this.canAccessDocumentLocation = canAccess;
     }
 
 
     /**
-     * Is canAccess.
+     * Is canAccessDocumentLocation.
      *
-     * @return the isCanAccess
+     * @return the isCanAccessDocumentLocation
      */
-    public Boolean isCanAccess() {
-      return canAccess;
+    public Boolean isCanAccessDocumentLocation() {
+      return canAccessDocumentLocation;
     }
 
     /**

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -705,13 +705,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
           String ecmsPageLink = explorerLink(path);
           builder.explorerUri(explorerUri(schema, host, port, ecmsPageLink));
           builder.secret(documentserverSecret);
-          boolean canAccessDocument = false;
-          if (path.startsWith(usersPath)) {
-            canAccessDocument = canEditDocument(node);
-          } else {
-            canAccessDocument = true;
-          }
-          builder.canAccess(canAccessDocument);
+          builder.canAccessDocumentLocation(canAccessDocumentLocation(path, userId));
 
           config = builder.build();
 
@@ -735,11 +729,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       config.getEditorPage().setComment(nodeComment(node));
       config.getEditorPage().setLastModifier(getLastModifier(node));
       config.getEditorPage().setLastModified(getLastModified(node));
-      if (path.startsWith(usersPath)) {
-        config.getEditorConfig().setCanAccess(canEditDocument(node));
-      } else {
-        config.getEditorConfig().setCanAccess(true);
-      }
+      config.getEditorConfig().setCanAccessDocumentLocation(canAccessDocumentLocation(path, userId));
 
       cachedEditorConfigStorage.saveConfig(config.getDocument().getKey(), config,false);
       cachedEditorConfigStorage.saveConfig(config.getDocId(),config,false);
@@ -831,14 +821,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     } else {
       builder.setAllowEdition(false);
     }
-
-    boolean canAccessDocument = false;
-    if (path.startsWith(usersPath)) {
-      canAccessDocument = canEditDocument(node);
-    } else {
-      canAccessDocument = true;
-    }
-    builder.canAccess(canAccessDocument);
+    builder.canAccessDocumentLocation(canAccessDocumentLocation(path, userId));
 
     Config config = builder.build();
     // Create users' config map and add first user
@@ -1225,6 +1208,29 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     }
     return getPages(versions, itemParPage, pageNum);
   }
+
+  private String extractSpacePrettyName(String path) {
+    if (path == null) {
+      return null;
+    }
+    String[] parts = path.split("/");
+
+    if (parts.length > 3 && "Groups".equals(parts[1]) && "spaces".equals(parts[2])) {
+      return parts[3];
+    }
+    return null;
+  }
+  private boolean canAccessDocumentLocation(String path, String userId) {
+    if (path.startsWith(usersPath)) {
+        return path.contains(userId);
+    }
+    if (path.startsWith(groupsPath)) {
+        String spaceName = extractSpacePrettyName(path);
+        Space space = spaceService.getSpaceByPrettyName(spaceName);
+        return space != null && spaceService.isMember(space, userId);
+    }
+    return false;
+}
 
   private <T> List<T> getPages(List<T> c, Integer pageSize, int nb) {
     if (c == null || c.isEmpty())

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -705,6 +705,13 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
           String ecmsPageLink = explorerLink(path);
           builder.explorerUri(explorerUri(schema, host, port, ecmsPageLink));
           builder.secret(documentserverSecret);
+          boolean canAccessDocument = false;
+          if (path.startsWith(usersPath)) {
+            canAccessDocument = canEditDocument(node);
+          } else {
+            canAccessDocument = true;
+          }
+          builder.canAccess(canAccessDocument);
 
           config = builder.build();
 
@@ -730,6 +737,8 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       config.getEditorPage().setLastModified(getLastModified(node));
       if (path.startsWith(usersPath)) {
         config.getEditorConfig().setCanAccess(canEditDocument(node));
+      } else {
+        config.getEditorConfig().setCanAccess(true);
       }
 
       cachedEditorConfigStorage.saveConfig(config.getDocument().getKey(), config,false);
@@ -826,6 +835,8 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     boolean canAccessDocument = false;
     if (path.startsWith(usersPath)) {
       canAccessDocument = canEditDocument(node);
+    } else {
+      canAccessDocument = true;
     }
     builder.canAccess(canAccessDocument);
 

--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -577,7 +577,7 @@
      * Create back button url.
      */
       var getBackUrl = function(config) {
-      if (config.editorConfig && !config.editorConfig.canAccess) {
+      if (config.editorConfig && !config.editorConfig.canAccessDocumentLocation) {
         const url = new URL(window.location.origin + eXo.env.portal.context + "/" + eXo.env.portal.portalName + "/restricted-drive");
         return url.toString();
       }


### PR DESCRIPTION
Before this change, a user who was a member of a space wanted to open a document location. He was redirected to the placeholder page and found that he cannot access the document location, which was incorrect since he had access to this document, which was not located in another user's personal drive.
This change corrects this behavior by setting the canAccess property to true to give access to all documents in the space located outside a user's personal drive, as is the case on prod now.
