### PR TITLE
fix: Refine document access check for users and space members - EXO-82012

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -65,6 +65,7 @@ import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 import javax.jcr.lock.Lock;
+import javax.jcr.nodetype.NodeType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.AutoCloseInputStream;
@@ -705,7 +706,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
           String ecmsPageLink = explorerLink(path);
           builder.explorerUri(explorerUri(schema, host, port, ecmsPageLink));
           builder.secret(documentserverSecret);
-          builder.canAccessDocumentLocation(canAccessDocumentLocation(path, userId));
+          builder.canAccessDocumentLocation(canAccessDocumentLocation(node, userId));
 
           config = builder.build();
 
@@ -729,7 +730,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       config.getEditorPage().setComment(nodeComment(node));
       config.getEditorPage().setLastModifier(getLastModifier(node));
       config.getEditorPage().setLastModified(getLastModified(node));
-      config.getEditorConfig().setCanAccessDocumentLocation(canAccessDocumentLocation(path, userId));
+      config.getEditorConfig().setCanAccessDocumentLocation(canAccessDocumentLocation(node, userId));
 
       cachedEditorConfigStorage.saveConfig(config.getDocument().getKey(), config,false);
       cachedEditorConfigStorage.saveConfig(config.getDocId(),config,false);
@@ -821,7 +822,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     } else {
       builder.setAllowEdition(false);
     }
-    builder.canAccessDocumentLocation(canAccessDocumentLocation(path, userId));
+    builder.canAccessDocumentLocation(canAccessDocumentLocation(node, userId));
 
     Config config = builder.build();
     // Create users' config map and add first user
@@ -1220,14 +1221,16 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     }
     return null;
   }
-  private boolean canAccessDocumentLocation(String path, String userId) {
+  private boolean canAccessDocumentLocation(Node node, String userId) throws RepositoryException {
+    String path = node.getPath();
+    String[] permissions = new String[] { PermissionType.READ };
     if (path.startsWith(usersPath)) {
-        return path.contains(userId);
+      return PermissionUtil.hasPermissions(node, userId, permissions);
     }
     if (path.startsWith(groupsPath)) {
         String spaceName = extractSpacePrettyName(path);
         Space space = spaceService.getSpaceByPrettyName(spaceName);
-        return space != null && spaceService.isMember(space, userId);
+        return space != null && (PermissionUtil.hasPermissions(node, userId, permissions) || spaceService.isMember(space, userId));
     }
     return false;
 }

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -65,7 +65,6 @@ import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 import javax.jcr.lock.Lock;
-import javax.jcr.nodetype.NodeType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.AutoCloseInputStream;


### PR DESCRIPTION
Prior to this change, the canAccessDocumentLocation method did not properly handle access checks for shared documents in user drives/ spaces. This change will ensure that document access checks correctly handle both user and space contexts. For user paths, permissions continue to be enforced through PermissionUtil.hasPermissions. For space paths, access is now granted if the user has explicit read permissions through PermissionUtil.hasPermissions also or is a member of the space. 