### PR TITLE
Fix: Fix an XSS vulnerability in backTo parameter when using OO - EXO-85054

### DIFF
--- a/webapp/src/main/java/org/exoplatform/onlyoffice/portlet/EditorPortlet.java
+++ b/webapp/src/main/java/org/exoplatform/onlyoffice/portlet/EditorPortlet.java
@@ -36,6 +36,7 @@ import javax.portlet.RenderMode;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
+import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.w3c.dom.Element;
 
 import org.exoplatform.container.ExoContainer;
@@ -186,7 +187,8 @@ public class EditorPortlet extends GenericPortlet {
             }
           }
           if (backTo != null) {
-            config.setBackTo(backTo);
+            String sanitizedBackUrl = HTMLSanitizer.sanitize(backTo);
+            config.setBackTo(sanitizedBackUrl);
           }
         } else {
           showError(i18n.getString("OnlyofficeEditorClient.ErrorTitle"),


### PR DESCRIPTION
Prior to this change, the OO editor URL parameters were not properly sanitized. Specifically, the backTo parameter could be manipulated to inject JavaScript payloads, which would then be executed in the browser. This change will introduce proper sanitization of the backTo parameter before it is rendered in the editor page.