### PR TITLE
Fix: Restrict backTo parameter to relative paths in onlyoffice - EXO-85055

### DIFF
--- a/webapp/src/main/java/org/exoplatform/onlyoffice/portlet/EditorPortlet.java
+++ b/webapp/src/main/java/org/exoplatform/onlyoffice/portlet/EditorPortlet.java
@@ -186,7 +186,7 @@ public class EditorPortlet extends GenericPortlet {
               config.getEditorConfig().setLang(Locale.getDefault().getLanguage());
             }
           }
-          if (backTo != null) {
+          if (backTo != null && backTo.matches("^/(?!/).*")) {
             String sanitizedBackUrl = HTMLSanitizer.sanitize(backTo);
             config.setBackTo(sanitizedBackUrl);
           }


### PR DESCRIPTION
Prior to this change, the document application did not properly validate the “backTo” URL parameter. Specifically, this parameter could be manipulated to include external domains (for example: .test.org). This change ensures proper validation of the “backTo” parameter by requiring that it begin with a single “/” and preventing the presence of “//” at the beginning. This ensures that “backTo” always refers to a relative path within the current domain.