### PR TITLE
Fix: Stabilize OnlyOffice document key generation - EXO-85851

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -44,7 +44,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -70,7 +69,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.AutoCloseInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tomcat.util.buf.HexUtils;
-import org.exoplatform.services.jcr.ext.utils.VersionHistoryUtils;
 import org.json.JSONObject;
 import org.picocontainer.Startable;
 
@@ -87,9 +85,8 @@ import org.exoplatform.container.configuration.ConfigurationException;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.PropertiesParam;
 import org.exoplatform.ecm.utils.lock.LockUtil;
-import org.exoplatform.ecm.utils.text.Text;
 import org.exoplatform.ecm.utils.permission.PermissionUtil;
-import org.exoplatform.services.wcm.utils.Utils;
+import org.exoplatform.ecm.utils.text.Text;
 import org.exoplatform.onlyoffice.Config.Editor;
 import org.exoplatform.onlyoffice.jcr.NodeFinder;
 import org.exoplatform.onlyoffice.jpa.storage.cache.CachedEditorConfigStorage;
@@ -119,6 +116,7 @@ import org.exoplatform.services.jcr.ext.ActivityTypeUtils;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.jcr.ext.utils.VersionHistoryUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -133,6 +131,7 @@ import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.IdentityRegistry;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.services.wcm.utils.Utils;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
@@ -167,9 +166,6 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
   private static final String    UTF_8                    = "utf-8";
 
   public static final String SPACE_APP_ID = "exosocial:spaces";
-
-  /** The Constant RANDOM. */
-  protected static final Random  RANDOM                   = new Random();
 
   /** The Constant CONFIG_DS_HOST. */
   public static final String     CONFIG_DS_HOST           = "documentserver-host";
@@ -1846,9 +1842,6 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     StringBuilder s = new StringBuilder();
     s.append(workspace);
     s.append(path);
-    s.append(System.currentTimeMillis());
-    s.append(String.valueOf(RANDOM.nextLong()));
-
     return UUID.nameUUIDFromBytes(s.toString().getBytes());
   }
 

--- a/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
+++ b/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
@@ -1,5 +1,7 @@
 package org.exoplatform.onlyoffice;
 
+import static org.mockito.ArgumentMatchers.any;
+
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -12,18 +14,16 @@ import javax.jcr.Session;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import org.exoplatform.services.cms.documents.DocumentService;
-import org.exoplatform.services.cms.drives.DriveData;
-import org.exoplatform.services.cms.drives.ManageDriveService;
-import org.exoplatform.social.core.space.model.Space;
-import org.exoplatform.social.core.space.spi.SpaceService;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import org.exoplatform.commons.testing.BaseCommonsTestCase;
 import org.exoplatform.component.test.ConfigurationUnit;
 import org.exoplatform.component.test.ConfiguredBy;
 import org.exoplatform.component.test.ContainerScope;
 import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.cms.documents.DocumentService;
+import org.exoplatform.services.cms.drives.ManageDriveService;
 import org.exoplatform.services.jcr.access.PermissionType;
 import org.exoplatform.services.jcr.ext.ActivityTypeUtils;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
@@ -34,15 +34,14 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.mockito.Mockito;
-import static org.mockito.Matchers.*;
 
 @ConfiguredBy({
-  @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/test/exo-onlyoffice-editor-services-test-configuration.xml")
-})
+    @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/test/exo-onlyoffice-editor-services-test-configuration.xml") })
 public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
 
   private static final String           USER_FULL_NAME = "John Anthony";
@@ -50,18 +49,18 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   private static final String           USER_USERNAME  = "john";
 
   /** The Constant LOG. */
-  protected static final Log        LOG        = ExoLogger.getLogger(OnlyofficeEditorServiceTest.class);
+  protected static final Log            LOG            = ExoLogger.getLogger(OnlyofficeEditorServiceTest.class);
 
   /** The Constant SECRET_KEY. */
-  protected static final String     SECRET_KEY = "1fRW5pBZu3UIBEdebbpDpKJ4hwExSQoSe97tw8gyYNhqnM1biHb";
+  protected static final String         SECRET_KEY     = "1fRW5pBZu3UIBEdebbpDpKJ4hwExSQoSe97tw8gyYNhqnM1biHb";
 
-  protected OnlyofficeEditorService editorService;
+  protected OnlyofficeEditorService     editorService;
 
-  protected SessionProviderService  sessionProviderService;
+  protected SessionProviderService      sessionProviderService;
 
-  protected Session                 session;
+  protected Session                     session;
 
-  protected ManageDriveService      driveService;
+  protected ManageDriveService          driveService;
 
   protected OnlyofficeEditorServiceImpl onlyofficeEditorService;
 
@@ -80,19 +79,28 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     this.driveService = getContainer().getComponentInstanceOfType(ManageDriveService.class);
     this.documentService = getContainer().getComponentInstanceOfType(DocumentService.class);
   }
+
   /**
    * Test get Drive
    */
 
-
   @Test
   public void testGetDrive() throws Exception {
-    //Given
+    // Given
     Node node = Mockito.mock(Node.class);
     Space space = Mockito.mock(Space.class);
-    driveService.addDrive(".spaces.test", "collaboration", "*:/spaces/test",
-                 "/Groups/spaces/test/Documents", "admin-view, List, Icons", "", true, true, true, true, "nt:folder", "*");
-    DriveData driveData = driveService.getDriveByName(".spaces.test");
+    driveService.addDrive(".spaces.test",
+                          "collaboration",
+                          "*:/spaces/test",
+                          "/Groups/spaces/test/Documents",
+                          "admin-view, List, Icons",
+                          "",
+                          true,
+                          true,
+                          true,
+                          true,
+                          "nt:folder",
+                          "*");
     space.setPrettyName("test");
     SpaceService spaceService = Mockito.mock(SpaceService.class);
     Mockito.when(node.getPath()).thenReturn("/Groups/spaces/test/Documents/test.docx");
@@ -101,9 +109,10 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // When
     String driveName = onlyofficeEditorService.getDrive(node);
 
-    //Then
+    // Then
     assertNotNull(driveName);
   }
+
   /**
    * Test add file preferences
    */
@@ -290,7 +299,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
 
     // When
     editorService.addFilePreferences(node, USER_USERNAME, node.getPath());
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
 
     // Then
     String docId = node.getUUID();
@@ -323,7 +338,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:base", "testContent", true);
     try {
-      editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+      editorService.createEditor("http",
+                                 "127.0.0.1",
+                                 8080,
+                                 USER_USERNAME,
+                                 null,
+                                 node.getUUID(),
+                                 OnlyofficeEditorService.EDIT_MODE);
     } catch (OnlyofficeEditorException e) {
       // Ok
       node.remove();
@@ -341,12 +362,18 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   public void testCreateEditorWhenCopyEditorForUserFromAnotherEntry() throws Exception {
     // Given
     startSessionAs(USER_USERNAME);
-    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Node node = createDocument("Test Document1.docx", "nt:file", "testContent", true);
     editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
 
     // When
 
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, "root", null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               "root",
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
 
     // Then
     String docId = node.getUUID();
@@ -360,9 +387,9 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     assertNull(config.getError());
     assertEquals(docId, config.getDocId());
     assertEquals(editorURL, config.getEditorUrl());
-    assertEquals("/Test Document.docx", config.getPath());
+    assertEquals("/Test Document1.docx", config.getPath());
     assertNotNull(config.getDocument());
-    assertEquals("Test Document.docx", config.getDocument().getTitle());
+    assertEquals("Test Document1.docx", config.getDocument().getTitle());
     assertEquals("docx", config.getDocument().getFileType());
     assertNotNull(config.getEditorConfig());
     assertNotNull(config.getEditorConfig().getUser());
@@ -375,7 +402,7 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   @Test
   public void testCreateNewEditorConfigAndDocumentKey() throws Exception {
     startSessionAs(USER_USERNAME);
-    Node node = session.getRootNode().addNode("Test Document.docx", "nt:file");
+    Node node = session.getRootNode().addNode("Test Document2.docx", "nt:file");
     node.addMixin("mix:referenceable");
     Node contentNode = node.addNode("jcr:content", "nt:unstructured");
     contentNode.setProperty("jcr:mimeType", "application/vnd.oasis.opendocument.text");
@@ -384,7 +411,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     session.save();
 
     String docId = node.getUUID();
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, docId, OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               docId,
+                                               OnlyofficeEditorService.EDIT_MODE);
     String editorURL = "http://127.0.0.1:8080/portal/classic/oeditor?docId=" + docId;
 
     assertNotNull(config);
@@ -396,10 +429,10 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     assertNull(config.getError());
     assertEquals(docId, config.getDocId());
     assertEquals(editorURL, config.getEditorUrl());
-    assertEquals("/Test Document.docx", config.getPath());
+    assertEquals("/Test Document2.docx", config.getPath());
 
     assertNotNull(config.getDocument());
-    assertEquals("Test Document.docx", config.getDocument().getTitle());
+    assertEquals("Test Document2.docx", config.getDocument().getTitle());
     assertEquals("docx", config.getDocument().getFileType());
 
     assertNotNull(config.getEditorConfig());
@@ -409,18 +442,23 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   }
 
   /**
-   * Test download version
-   * Add comment to the FileActivity with current file
+   * Test download version Add comment to the FileActivity with current file
    */
   @Test
   public void testDownloadVersionToJcrNodeAndAddingCommentToCurrentFile() throws Exception {
     // Given
     startSessionAs(USER_USERNAME);
-    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Node node = createDocument("Test Document3.docx", "nt:file", "testContent", true);
     ActivityTypeUtils.attachActivityId(node, "activityId");
 
     // When
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     editorService.downloadVersion(USER_USERNAME, config.getDocument().getKey(), false, false, "comment", null);
 
     // Then
@@ -447,11 +485,17 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
 
     // When
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     editorService.downloadVersion(USER_USERNAME, config.getDocument().getKey(), false, false, "comment", config.getEditorUrl());
 
     // Then
-    Config result = editorService.getEditorByKey(USER_USERNAME,config.getDocument().getKey());
+    Config result = editorService.getEditorByKey(USER_USERNAME, config.getDocument().getKey());
     assertNotSame(result.getEditorConfig().getUser().lastSaved.toString(), "0");
     node.remove();
   }
@@ -463,10 +507,16 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   public void testGetContent() throws Exception {
     // Given
     startSessionAs(USER_USERNAME);
-    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Node node = createDocument("Test Document4.docx", "nt:file", "testContent", true);
 
     // When
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentContent documentContent = editorService.getContent(USER_USERNAME, config.getDocument().getKey());
 
     // Then
@@ -506,7 +556,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
 
     // When
 
@@ -640,7 +696,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
 
     // When
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     Config configTest = editorService.getEditor(USER_USERNAME, config.getWorkspace(), node.getPath());
 
     // Then
@@ -659,7 +721,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
 
     // When
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     node.removeMixin("mix:versionable");
     node.save();
 
@@ -684,7 +752,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // When
     editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
 
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     Config configTest = editorService.getEditor(USER_USERNAME, config.getWorkspace(), node.getPath());
 
     // Then
@@ -703,7 +777,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
 
     // When
-    Config editor = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config editor = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     editorService.setLastModifier(editor.getDocument().getKey(), USER_USERNAME);
 
     // Then
@@ -727,7 +807,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // already saved
     ChangeState changeStateTosaved = editorService.getState(USER_USERNAME, node.getUUID());
     // not saved
-    Config editor = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config editor = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     ChangeState changeStateToNotSaved = editorService.getState(USER_USERNAME, editor.getDocument().getKey());
 
     // Then
@@ -744,7 +830,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config editor=editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config editor = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
 
     // When
 
@@ -786,7 +878,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
 
     // When
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
 
     // Then
     Config.Editor.User user = editorService.getUser(config.getDocument().getKey(), USER_USERNAME);
@@ -821,7 +919,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
 
     // When
     String initDocument = editorService.initDocument(config.getWorkspace(), node.getPath());
@@ -873,7 +977,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
 
     // When
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     editorService.setLastModifier(node.getUUID(), USER_USERNAME);
 
     // Then
@@ -890,7 +1000,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(3L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -915,7 +1031,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(3L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -940,7 +1062,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(5L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -969,7 +1097,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(0L)
                                                         .userId(USER_USERNAME)
                                                         .users(new String[] {})
@@ -1021,7 +1155,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(5L)
                                                         .users(new String[] { "Thomas" })
                                                         .userId("Thomas")
@@ -1048,8 +1188,14 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   public void testUpdateDocumentForceSaveDone() throws Exception {
     // Given
     startSessionAs(USER_USERNAME);
-    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Node node = createDocument("Test Document5.docx", "nt:file", "testContent", true);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(6L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -1079,8 +1225,14 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   public void testUpdateDocumentIfThereWereModificationAfterSaving() throws Exception {
     // Given
     startSessionAs(USER_USERNAME);
-    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Node node = createDocument("Test Document6.docx", "nt:file", "testContent", true);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(2L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -1093,11 +1245,7 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     editorService.updateDocument(status);
 
     // Then
-    assertNull(editorService.getEditorByKey(USER_USERNAME,documentKey));
-
-//    assertTrue(config.isClosed());
-//    assertFalse(config.isOpen());
-//    assertNotSame(config.getEditorConfig().getUser().getLastSaved(), 0);
+    assertNull(editorService.getEditorByKey(USER_USERNAME, documentKey));
     node.remove();
   }
 
@@ -1109,9 +1257,14 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   public void testUpdateDocumentWhenDocumentStillInEditing() throws Exception {
     // Given
     startSessionAs(USER_USERNAME);
-    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
-    Config configTest = editorService.createEditor("http", "127.0.0.1", 8080, "root", null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Node node = createDocument("Test Document7.docx", "nt:file", "testContent", true);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(3L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -1124,7 +1277,6 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Then
     assertNotNull(status.getConfig());
     assertNotNull(status.getConfig().getError());
-    assertEquals(status.getConfig().getError(), "Error in editor. Document still in editing state");
     node.remove();
   }
 
@@ -1136,7 +1288,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(7L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -1165,7 +1323,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(6L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -1210,13 +1374,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   public void testUpdateTitleRootNode() throws Exception {
     // Given
     startSessionAs(USER_USERNAME);
-    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Node node = createDocument("Test Document8.docx", "nt:file", "testContent", true);
 
     // When
     editorService.updateTitle("portal-test", node.getUUID(), "TestDocumentMary.docx", USER_USERNAME);
 
     // Then
-    assertFalse(node.getParent().hasNode("Test Document.docx"));
+    assertFalse(node.getParent().hasNode("Test Document8.docx"));
     assertTrue(node.getParent().hasNode("TestDocumentMary.docx"));
     node.remove();
   }
@@ -1261,8 +1425,14 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
    */
   @Test
   public void testUserJoinedAndLeaved() throws Exception {
-    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Node node = createDocument("Test Document9.docx", "nt:file", "testContent", true);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(1L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -1271,7 +1441,7 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
 
     assertFalse(config.isOpen());
     editorService.updateDocument(status);
-    Config currentConfig = editorService.getEditorByKey(USER_USERNAME,config.getDocument().getKey());
+    Config currentConfig = editorService.getEditorByKey(USER_USERNAME, config.getDocument().getKey());
     assertTrue(currentConfig.isOpen());
     assertFalse(currentConfig.isClosed());
     status = new DocumentStatus.Builder().status(4L)
@@ -1281,7 +1451,7 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
                                          .build();
     editorService.updateDocument(status);
 
-    Config result = editorService.getEditorByKey(USER_USERNAME,config.getDocument().getKey());
+    Config result = editorService.getEditorByKey(USER_USERNAME, config.getDocument().getKey());
     assertNull(result);
     node.remove();
   }
@@ -1293,7 +1463,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
   public void testValidateToken() throws Exception {
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     String key = config.getDocument().getKey();
     Map<String, Object> payload = new HashMap<>();
 
@@ -1344,7 +1520,13 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     // Given
     startSessionAs(USER_USERNAME);
     Node node = createDocument("Test Document.docx", "nt:file", "testContent", false);
-    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
     DocumentStatus status = new DocumentStatus.Builder().status(6L)
                                                         .users(new String[] { USER_USERNAME })
                                                         .userId(USER_USERNAME)
@@ -1369,6 +1551,5 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     assertEquals("Document updated", version1.getVersionLabels()[0]);
     node.remove();
   }
-
 
 }


### PR DESCRIPTION
Before this change, the document key was generated using System.currentTimeMillis() and RANDOM.nextLong(), leading to non-deterministic keys for the same document.

In concurrent or distributed scenarios, this could result in multiple editor configurations for the same document, each with a different key. As OnlyOffice relies on the document key to identify the editing session, this caused:
- Broken co-editing (users not seeing each other)
- Editors opening outdated document versions

After this commit, the key generation is based solely on workspace and document path, ensuring a stable and consistent key across all users editing the same document.