### PR TITLE
Fix: Fix OnlyOffice "Version has been changed" error by incorporating lastModified in key generation - EXO-86398

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -685,7 +685,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
           builder.userName(user.getDisplayName());
           builder.lastModifier(getLastModifier(node));
           builder.lastModified(getLastModified(node));
-          String key = generateId(workspace, path).toString();
+          String key = generateId(workspace, path, getLastModified(node)).toString();
 
           builder.key(key);
           StringBuilder platformUrl = platformUrl(schema, host, port);
@@ -787,7 +787,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       builder.userId(user.getUserName());
       builder.userName(user.getDisplayName());
     }
-    String key = generateId(workspace, path).toString();
+    String key = generateId(workspace, path, getLastModified(node)).toString();
     builder.key(key);
     StringBuilder platformUrl = platformUrl(schema, host, port);
 
@@ -1866,10 +1866,13 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
    * @param path the path
    * @return the uuid
    */
-  protected UUID generateId(String workspace, String path) {
+  protected UUID generateId(String workspace, String path, String lastModified) {
     StringBuilder s = new StringBuilder();
     s.append(workspace);
     s.append(path);
+    if (lastModified != null) {
+      s.append(lastModified);
+    }
     return UUID.nameUUIDFromBytes(s.toString().getBytes());
   }
 
@@ -3497,7 +3500,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     builder.userName(user.getDisplayName());
     builder.lastModifier(getLastModifier(node));
     builder.lastModified(getLastModified(node));
-    String key = generateId(workspace, node.getPath()).toString();
+    String key = generateId(workspace, node.getPath(), getLastModified(node)).toString();
 
     builder.key(key);
     String platformUrl = System.getProperty("exo.base.url");


### PR DESCRIPTION
Prior to this change, the generateId method used only the workspace and path to generate the document key. 
This resulted in a strictly static key that never changed, even after the file was modified and saved. 
When OnlyOffice attempted to open a document while a previous session with the same key was still lingering in the server's cache or memory, it detected a mismatch between the expected file state and the current session, triggering the "Version has been changed" error.
After this commit, the lastModified timestamp has been added to the generateId method. 
The document key is now derived from workspace, path, and lastModified which ensures that the key remains stable for concurrent editing (enabling co-editing) but rotates automatically as soon as the document is updated in the JCR. This rotation allows OnlyOffice to gracefully clear the old session cache and initialize a fresh session, resolving the version conflict error.