### PR TITLE
fix: Add placeholder page when the user accesses another user's personal drive - EXO-82012

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/Config.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/Config.java
@@ -143,9 +143,9 @@ public class Config implements Externalizable {
     // Editor.User
     protected String       userId, name;
     
+    protected boolean      canAccessDocumentLocation;
   
-  
-    protected boolean allowEdition = true;
+    protected boolean      allowEdition = true;
 
     /**
      * Instantiates a new builder.
@@ -433,6 +433,17 @@ public class Config implements Externalizable {
     }
 
     /**
+     * Sets can access document path or not.
+     *
+     * @param canAccess the access document path
+     * @return the builder
+     */
+    public Builder canAccessDocumentLocation(boolean canAccess) {
+      this.canAccessDocumentLocation = canAccess;
+      return this;
+    }
+
+    /**
      * Download url.
      *
      * @param downloadUrl the download url
@@ -485,6 +496,7 @@ public class Config implements Externalizable {
       Document document = new Document(key, fileType, title, url, info, permissions);
       Editor.User user = new Editor.User(userId, name);
       Editor editor = new Editor(callbackUrl, lang, mode, user);
+      editor.setCanAccessDocumentLocation(this.canAccessDocumentLocation);
       EditorPage editorPage = new EditorPage(comment, renameAllowed, displayPath, lastModifier, lastModified,drive);
       Config config = new Config(documentserverUrl,
                                  platformRestUrl,
@@ -921,6 +933,8 @@ public class Config implements Externalizable {
     /** The mode. */
     protected String       mode;
 
+    protected boolean      canAccessDocumentLocation;
+
     /**
      * Instantiates a new editor.
      *
@@ -935,6 +949,25 @@ public class Config implements Externalizable {
       this.lang = lang;
       this.mode = mode != null && mode.equals("fillform") ? "edit" : mode;
       this.user = user;
+    }
+
+    /**
+     * Sets if can access to document path.
+     *
+     * @param canAccess the can access variable
+     */
+    public void setCanAccessDocumentLocation(boolean canAccess) {
+      this.canAccessDocumentLocation = canAccess;
+    }
+
+
+    /**
+     * Is canAccessDocumentLocation.
+     *
+     * @return the isCanAccessDocumentLocation
+     */
+    public Boolean isCanAccessDocumentLocation() {
+      return canAccessDocumentLocation;
     }
 
     /**

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -705,6 +705,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
           String ecmsPageLink = explorerLink(path);
           builder.explorerUri(explorerUri(schema, host, port, ecmsPageLink));
           builder.secret(documentserverSecret);
+          builder.canAccessDocumentLocation(canAccessDocumentLocation(node, userId));
 
           config = builder.build();
 
@@ -728,6 +729,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       config.getEditorPage().setComment(nodeComment(node));
       config.getEditorPage().setLastModifier(getLastModifier(node));
       config.getEditorPage().setLastModified(getLastModified(node));
+      config.getEditorConfig().setCanAccessDocumentLocation(canAccessDocumentLocation(node, userId));
 
       cachedEditorConfigStorage.saveConfig(config.getDocument().getKey(), config,false);
       cachedEditorConfigStorage.saveConfig(config.getDocId(),config,false);
@@ -819,6 +821,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     } else {
       builder.setAllowEdition(false);
     }
+    builder.canAccessDocumentLocation(canAccessDocumentLocation(node, userId));
 
     Config config = builder.build();
     // Create users' config map and add first user
@@ -1205,6 +1208,31 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     }
     return getPages(versions, itemParPage, pageNum);
   }
+
+  private String extractSpacePrettyName(String path) {
+    if (path == null) {
+      return null;
+    }
+    String[] parts = path.split("/");
+
+    if (parts.length > 3 && "Groups".equals(parts[1]) && "spaces".equals(parts[2])) {
+      return parts[3];
+    }
+    return null;
+  }
+  private boolean canAccessDocumentLocation(Node node, String userId) throws RepositoryException {
+    String path = node.getPath();
+    String[] permissions = new String[] { PermissionType.READ };
+    if (path.startsWith(usersPath)) {
+      return PermissionUtil.hasPermissions(node, userId, permissions);
+    }
+    if (path.startsWith(groupsPath)) {
+        String spaceName = extractSpacePrettyName(path);
+        Space space = spaceService.getSpaceByPrettyName(spaceName);
+        return space != null && (PermissionUtil.hasPermissions(node, userId, permissions) || spaceService.isMember(space, userId));
+    }
+    return false;
+}
 
   private <T> List<T> getPages(List<T> c, Integer pageSize, int nb) {
     if (c == null || c.isEmpty())

--- a/webapp/src/main/webapp/js/onlyoffice.js
+++ b/webapp/src/main/webapp/js/onlyoffice.js
@@ -577,6 +577,10 @@
      * Create back button url.
      */
       var getBackUrl = function(config) {
+      if (config.editorConfig && !config.editorConfig.canAccessDocumentLocation) {
+        const url = new URL(window.location.origin + eXo.env.portal.context + "/" + eXo.env.portal.portalName + "/restricted-drive");
+        return url.toString();
+      }
       if(!config.backTo){
         return config.explorerUrl;
       }


### PR DESCRIPTION
Before this change, a user creates a document in his personal drive, then attaches it to an article in a space. Another user who is a member of the same space goes to the location of the first user's document, which is restricted because it is located in his personal drive. This change corrects this behavior and displays a placeholder page to the second user to indicate that he does not have access to this drive.