### PR TITLE
fix: Read eoo:versionOwner from live node instead of frozen node - EXO-86996

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -2137,16 +2137,11 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
                         node.getUUID(), node.getPath(), userId);
             }
           }
-          // Use current node insted of frozen one when it doesn't exist yet.
-          Node frozen = node;
           boolean versionable = node.isNodeType("mix:versionable");
-          if (versionable && node.getBaseVersion().hasNode("jcr:frozenNode")) {
-            frozen = node.getBaseVersion().getNode("jcr:frozenNode");
-          }
 
           if(LOG.isDebugEnabled()) {
-            LOG.debug("Current Base version is (id={},path{}) (Node (id={},path={}), userId={})",
-                      frozen.getUUID(), frozen.getPath(),node.getUUID(), node.getPath(), userId);
+            LOG.debug("Node is versionable={} (Node (id={},path={}), userId={})",
+                      versionable, node.getUUID(), node.getPath(), userId);
           }
           // Used in DocumentUpdateActivityListener
           boolean sameModifier = false;
@@ -2221,9 +2216,14 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
           }
 
 
+          // Read eoo:versionOwner from the live node.
+          // The frozen node snapshot always captures the cleared ("") value written
+          // just before checkin, so it cannot detect same-user accumulation across
+          // co-editing forcesave cycles. The live node holds the current session's
+          // ownership state set at the end of the previous save cycle.
           String versioningUser = null;
-          if (frozen.hasProperty("eoo:versionOwner")) {
-            versioningUser = frozen.getProperty("eoo:versionOwner").getString();
+          if (node.hasProperty("eoo:versionOwner")) {
+            versioningUser = node.getProperty("eoo:versionOwner").getString();
           }
 
           if(LOG.isDebugEnabled()) {

--- a/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
+++ b/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
@@ -1461,4 +1461,45 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     node.remove();
   }
 
+  @Test
+  public void testVersionOwnerReadFromLiveNode() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", false);
+    String nodePath = node.getPath();
+    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    String key = config.getDocument().getKey();
+
+    DocumentStatus openStatus = new DocumentStatus.Builder().status(1L)
+                                                            .users(new String[] { USER_USERNAME })
+                                                            .userId(USER_USERNAME)
+                                                            .key(key)
+                                                            .saved(true)
+                                                            .build();
+    editorService.updateDocument(openStatus);
+
+    assertTrue("Node should be versionable", node.isNodeType("mix:versionable"));
+
+    editorService.downloadVersion(USER_USERNAME, key, false, false, null, null);
+
+    Node reloaded = editorService.getDocument(null, nodePath);
+    assertTrue("eoo:versionOwner should be present on live node after save",
+               reloaded.hasProperty("eoo:versionOwner"));
+
+    editorService.downloadVersion(USER_USERNAME, key, false, true, null, null);
+
+    reloaded = editorService.getDocument(null, nodePath);
+    assertTrue("eoo:versionOwner should be present on live node after forcesave",
+               reloaded.hasProperty("eoo:versionOwner"));
+
+    editorService.downloadVersion(USER_USERNAME, key, false, false, null, null);
+
+    reloaded = editorService.getDocument(null, nodePath);
+    assertTrue("eoo:versionOwner should be present on live node after second normal save",
+               reloaded.hasProperty("eoo:versionOwner"));
+
+    javax.jcr.version.VersionHistory vh = reloaded.getVersionHistory();
+    assertTrue("Should have at least 2 versions (root + saved)", vh.getAllVersions().getSize() >= 2);
+    node.remove();
+  }
+
 }

--- a/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
+++ b/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
@@ -1370,5 +1370,95 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     node.remove();
   }
 
+  @Test
+  public void testVersionAccumulationSameUser() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", false);
+    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    String key = config.getDocument().getKey();
+
+    DocumentStatus openStatus = new DocumentStatus.Builder().status(1L)
+                                                            .users(new String[] { USER_USERNAME })
+                                                            .userId(USER_USERNAME)
+                                                            .key(key)
+                                                            .saved(true)
+                                                            .build();
+    editorService.updateDocument(openStatus);
+
+    editorService.downloadVersion(USER_USERNAME, key, false, false, null, null);
+    editorService.downloadVersion(USER_USERNAME, key, false, false, null, null);
+
+    List<Version> versions = editorService.getVersions("portal-test", node.getUUID(), 10, 0);
+    assertNotNull(versions);
+    assertEquals("Same user saves create versions (each downloadVersion call creates 1 version)", 2, versions.size());
+    Version v1 = versions.get(0);
+    Version v2 = versions.get(1);
+    assertEquals(USER_USERNAME, v1.getAuthor());
+    assertEquals(USER_USERNAME, v2.getAuthor());
+    node.remove();
+  }
+
+  @Test
+  public void testVersionAccumulationDifferentUsers() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", false);
+    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    String key = config.getDocument().getKey();
+
+    DocumentStatus openStatus = new DocumentStatus.Builder().status(1L)
+                                                            .users(new String[] { USER_USERNAME })
+                                                            .userId(USER_USERNAME)
+                                                            .key(key)
+                                                            .saved(true)
+                                                            .build();
+    editorService.updateDocument(openStatus);
+
+    editorService.downloadVersion(USER_USERNAME, key, false, false, null, null);
+
+    editorService.createEditor("http", "127.0.0.1", 8080, "root", null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    DocumentStatus openStatus2 = new DocumentStatus.Builder().status(1L)
+                                                             .users(new String[] { "root" })
+                                                             .userId("root")
+                                                             .key(key)
+                                                             .saved(true)
+                                                             .build();
+    editorService.updateDocument(openStatus2);
+    editorService.downloadVersion("root", key, false, false, null, null);
+
+    List<Version> versions = editorService.getVersions("portal-test", node.getUUID(), 10, 0);
+    assertNotNull(versions);
+    assertEquals("Different user saves produce separate versions", 2, versions.size());
+    assertEquals(USER_USERNAME, versions.get(0).getAuthor());
+    assertEquals("root", versions.get(1).getAuthor());
+    node.remove();
+  }
+
+  @Test
+  public void testVersionAccumulationAfterForcesave() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", false);
+    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    String key = config.getDocument().getKey();
+
+    DocumentStatus openStatus = new DocumentStatus.Builder().status(1L)
+                                                            .users(new String[] { USER_USERNAME })
+                                                            .userId(USER_USERNAME)
+                                                            .key(key)
+                                                            .saved(true)
+                                                            .build();
+    editorService.updateDocument(openStatus);
+
+    editorService.downloadVersion(USER_USERNAME, key, false, false, null, null);
+    editorService.downloadVersion(USER_USERNAME, key, false, true, null, null);
+    editorService.downloadVersion(USER_USERNAME, key, false, false, null, null);
+
+    List<Version> versions = editorService.getVersions("portal-test", node.getUUID(), 10, 0);
+    assertNotNull(versions);
+    assertEquals("Three saves (normal, forcesave, normal) produce 3 versions", 3, versions.size());
+    assertEquals(USER_USERNAME, versions.get(0).getAuthor());
+    assertEquals(USER_USERNAME, versions.get(1).getAuthor());
+    assertEquals(USER_USERNAME, versions.get(2).getAuthor());
+    node.remove();
+  }
 
 }

--- a/services/src/test/resources/logback-test.xml
+++ b/services/src/test/resources/logback-test.xml
@@ -1,0 +1,4 @@
+<configuration>
+  <logger name="org.exoplatform.onlyoffice.OnlyofficeEditorServiceImpl" level="DEBUG"/>
+  <root level="INFO"/>
+</configuration>


### PR DESCRIPTION
The frozen node snapshot always captures the cleared ("") value written just before check-in, so it cannot detect same-user accumulation across co-editing force-save cycles. Reading from the live node fixes this.