### PR TITLE
fix: retain closed editor configs for late callbacks - EXO-87646

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -37,7 +37,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>OnlyOffice addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.39</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.50</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
@@ -383,8 +383,6 @@ public interface OnlyofficeEditorService {
 
   String getDocumentServiceSecret();
 
-  void closeWithoutModification(String userId, String key);
-
   /**
    * Checks if the document is opened for edition by multiple users
    * @param key Document key

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -183,6 +183,12 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
   /** The Constant CONFIG_DS_SECRET. */
   public static final String     CONFIG_DS_SECRET         = "documentserver-secret";
 
+  /** Retention for closed editor configs kept to handle late OnlyOffice callbacks. */
+  public static final String     CONFIG_CLOSED_CONFIG_RETENTION_MS = "editor-config-closed-retention-ms";
+
+  /** Default closed config retention: two hours. */
+  protected static final long    DEFAULT_CLOSED_CONFIG_RETENTION_MS = 2 * 60 * 60 * 1000L;
+
   /**
    * Configuration key for Document Server's allowed hosts in requests from a DS
    * to eXo side.
@@ -556,7 +562,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
    * @throws OnlyofficeEditorException the onlyoffice editor exception
    */
   protected Config getEditor(String userId, String docId, boolean createCoEditing) throws OnlyofficeEditorException {
-    Map<String, Config> configs = cachedEditorConfigStorage.getConfigsByDocId(docId);
+    Map<String, Config> configs = cachedEditorConfigStorage.getActiveConfigsByDocId(docId);
     if (configs != null && !configs.isEmpty()) {
       Config config = configs.get(userId);
       if (config != null && createCoEditing && configs.size() > 1) {
@@ -623,6 +629,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
                              String userId,
                              String workspace,
                              String docId, String mode) throws OnlyofficeEditorException, RepositoryException {
+    cleanupExpiredClosedConfigs();
     if (workspace == null) {
       workspace = jcrService.getCurrentRepository().getConfiguration().getDefaultWorkspaceName();
     }
@@ -646,7 +653,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       // we should care about concurrent calls here
       activeLock.lock();
       try {
-        Map<String, Config> configs = cachedEditorConfigStorage.getConfigsByDocId(docId);
+        Map<String, Config> configs = cachedEditorConfigStorage.getActiveConfigsByDocId(docId);
         if (configs != null && !configs.isEmpty()) {
           config = getEditor(userId, docId, true);
           if (config == null) {
@@ -930,6 +937,94 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
   }
 
   /**
+   * Grace period for retaining closed configs so late OnlyOffice callbacks can still be resolved.
+   */
+  protected long closedConfigRetentionMs() {
+    String value = config.get(CONFIG_CLOSED_CONFIG_RETENTION_MS);
+    if (StringUtils.isNotBlank(value)) {
+      try {
+        return Long.parseLong(value);
+      } catch (NumberFormatException e) {
+        LOG.warn("Invalid value for " + CONFIG_CLOSED_CONFIG_RETENTION_MS + ": " + value + ". Using default.");
+      }
+    }
+    return DEFAULT_CLOSED_CONFIG_RETENTION_MS;
+  }
+
+  /**
+   * Opportunistic cleanup of old closed configs
+   */
+  protected void cleanupExpiredClosedConfigs() {
+    try {
+      long expirationTime = System.currentTimeMillis() - closedConfigRetentionMs();
+      int deleted = cachedEditorConfigStorage.deleteClosedConfigsBefore(expirationTime);
+      if (deleted > 0 && LOG.isDebugEnabled()) {
+        LOG.debug("Deleted {} expired OnlyOffice editor configs", deleted);
+      }
+    } catch (Exception e) {
+      LOG.warn("Cannot cleanup expired OnlyOffice editor configs", e);
+    }
+  }
+
+  /**
+   * Resolve the config to use for a callback. OnlyOffice can send callbacks with
+   * userdata.userId, users[0], or the callback URL user.
+   */
+  protected Config resolveStatusConfig(DocumentStatus status, Map<String, Config> configs) {
+    String statusUserId = status.getUserId();
+    if (StringUtils.isNotBlank(statusUserId)) {
+      return configs.get(statusUserId);
+    }
+
+    String lastUserId = status.getLastUser();
+    if (StringUtils.isNotBlank(lastUserId)) {
+      return configs.get(lastUserId);
+    }
+
+    if (configs.size() == 1) {
+      return configs.values().iterator().next();
+    }
+    return null;
+  }
+
+  protected String[] safeUsers(DocumentStatus status) {
+    return status.getUsers() != null ? status.getUsers() : new String[0];
+  }
+
+  protected int activeConfigCount(Map<String, Config> configs) {
+    if (configs == null || configs.isEmpty()) {
+      return 0;
+    }
+    return (int) configs.values()
+                        .stream()
+                        .filter(c -> c != null && !c.isClosed())
+                        .count();
+  }
+
+  /**
+   * Mark every config for the key closed and retain it for late callbacks.
+   */
+  protected void closeConfigs(String key, Map<String, Config> configs) {
+    if (configs == null || configs.isEmpty()) {
+      return;
+    }
+    configs.values().forEach(c -> {
+      if (c != null) {
+        c.closed();
+        cachedEditorConfigStorage.saveConfig(List.of(key, c.getDocId()), c, false);
+      }
+    });
+  }
+
+  protected boolean hasActiveConfigForDifferentKey(String docId, String key) {
+    Map<String, Config> activeConfigs = cachedEditorConfigStorage.getActiveConfigsByDocId(docId);
+    return activeConfigs != null
+        && activeConfigs.values()
+                        .stream()
+                        .anyMatch(c -> c != null && !key.equals(c.getDocument().getKey()));
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override
@@ -940,7 +1035,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       if (config != null) {
         validateUser(userId, config);
         String[] users = getActiveUsers(configs);
-        return new ChangeState(false, config.getError(), users);
+        return new ChangeState(config.isClosed() && users.length == 0, config.getError(), users);
       } else {
         throw new BadParameterException("User editor not found " + userId);
       }
@@ -957,166 +1052,126 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
   public void updateDocument(DocumentStatus status) throws OnlyofficeEditorException, RepositoryException {
     String key = status.getKey();
     Map<String, Config> configs = cachedEditorConfigStorage.getConfigsByKey(key);
-    if (configs != null && !configs.isEmpty()) {
-      Config config = configs.get(status.getUserId());
-      if (config != null) {
-        status.setConfig(config);
-        validateUser(status.getUserId(), config);
+    if (configs == null || configs.isEmpty()) {
+      throw new BadParameterException("File key not found " + key);
+    }
 
-        String nodePath = nodePath(config.getWorkspace(), config.getPath());
+    Config config = resolveStatusConfig(status, configs);
+    if (config == null) {
+      throw new BadParameterException("User editor not found " + status.getUserId());
+    }
 
-        // status of the document. Can have the following values:
-        // 0 - no document with the key identifier could be found,
-        // 1 - document is being edited (user opened an editor),
-        // 2 - document is ready for saving (last user closed it),
-        // 3 - document saving error has occurred,
-        // 4 - document is closed with no changes (last user closed it)
-        // 6 - document is being edited, but the current document state is
-        // saved,
-        // 7 - error has occurred while force saving the document.
-        long statusCode = status.getStatus();
+    status.setConfig(config);
+    validateUser(config.getEditorConfig().getUser().getId(), config);
 
-        if (LOG.isDebugEnabled()) {
-          LOG.debug(">> Onlyoffice status " + statusCode + " for " + key + ". URL: " + status.getUrl() + ". Users: "
-              + Arrays.toString(status.getUsers()) + " << Local file: " + nodePath);
-        }
+    String nodePath = nodePath(config.getWorkspace(), config.getPath());
 
-        if (statusCode == 0) {
-          // Onlyoffice doesn't know about such document: we clean our records
-          // and raise an error
-          cachedEditorConfigStorage.deleteConfig(List.of(key,config.getDocId()), config);
-          LOG.warn("Received Onlyoffice status: no document with the key identifier could be found. Key: " + key + ". Document: "
-              + nodePath);
-          throw new OnlyofficeEditorException("Error editing document: document ID not found");
-        } else if (statusCode == 1) {
-          // while "document is being edited" (1) will come just before
-          // "document is ready for saving"
-          // (2) we could do nothing at this point, indeed need study how
-          // Onlyoffice behave in different
-          // situations when user leave page open or browser
-          // hangs/crashes/killed - it still could be useful
-          // here to make a cleanup
-          // Sync users from the status to active config: this should close
-          // configs of gone users
-          syncUsers(configs, status.getUsers());
-        } else if (statusCode == 2) {
-          Editor.User lastUser = getUser(key, status.getLastUser());
-          Editor.User lastModifier = getLastModifier(key);
-          // We download if there were modifications after the last saving.
-          if (!lastModifier.getId().equals(lastUser.getId()) ||
-              (lastModifier.getId().equals(lastUser.getId()) && lastUser.getLastModified() > lastUser.getLastSaved())) {
-            //lastUser is the user which send the last modification to OO
-            //lastModifier is the user which eXo knows as last modifier
-            //if lastModifier!=lastUser, it means that there a modification in OO which is not in eXo.
-            //in this case, we download from OO to exo
+    // status of the document. Can have the following values:
+    // 0 - no document with the key identifier could be found,
+    // 1 - document is being edited (user opened an editor),
+    // 2 - document is ready for saving (last user closed it),
+    // 3 - document saving error has occurred,
+    // 4 - document is closed with no changes (last user closed it)
+    // 6 - document is being edited, but the current document state is saved,
+    // 7 - error has occurred while force saving the document.
+    long statusCode = status.getStatus();
 
-            //if lastModifer and last user are the same, we download from oo to exo only if
-            //lastModifiedDate>lastSavedDate
-            downloadClosed(status);
-          } else {
-            config.closed();
-            broadcastEvent(status, OnlyofficeEditorService.EDITOR_CLOSED_EVENT);
-          }
-          configs.values().forEach(c -> {
-            if (!c.isCreated()) {
-              cachedEditorConfigStorage.deleteConfig(List.of(key, c.getDocId()), c);
-            }
-          });
-        } else if (statusCode == 3) {
-          // it's an error of saving in Onlyoffice
-          // we sync to remote editors list first
-          syncUsers(configs, status.getUsers());
-          if (configs.size() <= 1) {
-            // if one or zero users we can save it
-            String url = status.getUrl();
-            if (url != null && url.length() > 0) {
-              // if URL available then we can download it assuming it's last
-              // successful modification the same behaviour as for status (2)
-              downloadClosed(status);
-              cachedEditorConfigStorage.deleteConfig(List.of(key,config.getDocId()), config);
-              config.setError("Error in editor (" + status.getError() + "). Last change was successfully saved");
-              fireError(status);
-              broadcastEvent(status, OnlyofficeEditorService.EDITOR_ERROR_EVENT);
-              LOG.warn("Received Onlyoffice error of saving document. Key: " + key + ". Users: "
-                  + Arrays.toString(status.getUsers()) + ". Error: " + status.getError()
-                  + ". Last change was successfully saved for " + nodePath);
-            } else {
-              // if error without content URL and last user: it's error state
-              LOG.warn("Received Onlyoffice error of saving document without changes URL. Key: " + key + ". Users: "
-                  + Arrays.toString(status.getUsers()) + ". Document: " + nodePath + ". Error: " + status.getError());
-              config.setError("Error in editor (" + status.getError() + "). No changes saved");
-              // Update cached (for replicated cache)
-              cachedEditorConfigStorage.saveConfig(List.of(key,config.getDocId()), config,false);
-              fireError(status);
-              broadcastEvent(status, OnlyofficeEditorService.EDITOR_ERROR_EVENT);
-              // No sense to throw an ex here: it will be caught by the
-              // caller (REST) and returned to the Onlyoffice server as 500
-              // response, but it doesn't deal with it and will try send the
-              // status again.
-            }
-          } else {
-            // otherwise we assume other user will save it later
-            LOG.warn("Received Onlyoffice error of saving document with several editors. Key: " + key + ". Users: "
-                + Arrays.toString(status.getUsers()) + ". Document: " + nodePath);
-            config.setError("Error in editor. Document still in editing state");
-            // Update cached (for replicated cache)
-            cachedEditorConfigStorage.saveConfig(List.of(key,config.getDocId()), config,false);
-            fireError(status);
-            broadcastEvent(status, OnlyofficeEditorService.EDITOR_ERROR_EVENT);
-          }
-        } else if (statusCode == 4) {
-          // user(s) haven't changed the document but closed it: sync users to
-          // fire onLeaved event(s)
-          syncUsers(configs, status.getUsers());
-          // and remove this document from active configs
-          //as this status is sent only when the last user closed without modification,
-          //we can delete all configs of this doc
-          configs.values().forEach(c -> {
-            if (!c.isCreated()) {
-              cachedEditorConfigStorage.deleteConfig(List.of(key, c.getDocId()), c);
-            }
-          });
-        } else if (statusCode == 6) {
-          // forcedsave done, save the version with its URL
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Received Onlyoffice forced saved document. Key: " + key + ". Users: " + Arrays.toString(status.getUsers())
-                + ". Document " + nodePath + ". URL: " + status.getUrl() + ". Download: " + status.isSaved());
-          }
-          // Here we decide if we need to download content or just save the link
-          if (status.saved == null || status.isSaved()) {
-            LOG.debug("Document is save, and we need to download it (Node (id={}), userId={})",
-                        status.getConfig().getDocId(), status.getUserId());
-            downloadVersion(status);
-          } else {
-            saveLink(status.getUserId(), key, status.getUrl());
-          }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(">> Onlyoffice status " + statusCode + " for " + key + ". URL: " + status.getUrl() + ". Users: "
+          + Arrays.toString(status.getUsers()) + " << Local file: " + nodePath);
+    }
 
-        } else if (statusCode == 7) {
-          // For forcedsave error, we may decide next step according
-          // status.getError():
-          // TODO more precise error handling:
-          // 0 No errors.
-          // 1 Document key is missing or no document with such key could be
-          // found.
-          // 2 Callback url not correct.
-          // 3 Internal server error.
-          // 4 No changes were applied to the document before the forcesave
-          // command was received.
-          // 5 Command not correct.
-          // 6 Invalid token.
-          LOG.error("Received Onlyoffice error of forced saving of document. Key: " + key + ". Users: "
-              + Arrays.toString(status.getUsers()) + ". Document: " + nodePath + ". Error: " + status.getError() + ". URL: "
-              + status.getUrl() + ". Download: " + status.isSaved());
+    if (statusCode == 0) {
+      // Onlyoffice doesn't know about such document. Keep a closed record for a grace period
+      // instead of hard deleting immediately, so concurrent platform flows can still resolve it.
+      config.setError("Error editing document: document ID not found");
+      closeConfigs(key, configs);
+      LOG.warn("Received Onlyoffice status: no document with the key identifier could be found. Key: " + key + ". Document: "
+          + nodePath);
+      throw new OnlyofficeEditorException("Error editing document: document ID not found");
+    } else if (statusCode == 1) {
+      // If this is a late open notification for an old key after a new active key was created,
+      // keep the old config closed and do not reactivate it for docId lookup.
+      if (config.isClosed() && hasActiveConfigForDifferentKey(config.getDocId(), key)) {
+        LOG.warn("Ignoring late open status for superseded OnlyOffice key " + key + ". Document: " + nodePath);
+      } else {
+        syncUsers(configs, safeUsers(status));
+      }
+    } else if (statusCode == 2) {
+      Editor.User lastUser = getUser(key, status.getLastUser());
+      if (lastUser == null) {
+        lastUser = config.getEditorConfig().getUser();
+      }
+      Editor.User lastModifier = getLastModifier(key);
+      if (lastModifier == null) {
+        lastModifier = lastUser;
+      }
+      // Download if OO provides a URL, or if our local timestamps indicate unsaved changes.
+      boolean hasUrl = StringUtils.isNotBlank(status.getUrl());
+      boolean hasUnsavedChanges = lastModifier != null && lastUser != null
+          && (!lastModifier.getId().equals(lastUser.getId()) || lastUser.getLastModified() > lastUser.getLastSaved());
+      if (hasUrl || hasUnsavedChanges) {
+        downloadClosed(status);
+      } else {
+        config.closed();
+        cachedEditorConfigStorage.saveConfig(List.of(key, config.getDocId()), config, false);
+        broadcastEvent(status, OnlyofficeEditorService.EDITOR_CLOSED_EVENT);
+      }
+      closeConfigs(key, configs);
+    } else if (statusCode == 3) {
+      // it's an error of saving in Onlyoffice
+      syncUsers(configs, safeUsers(status));
+      if (activeConfigCount(configs) <= 1) {
+        String url = status.getUrl();
+        if (StringUtils.isNotBlank(url)) {
+          // if URL available then we can download it assuming it's last successful modification
+          downloadClosed(status);
+          config.setError("Error in editor (" + status.getError() + "). Last change was successfully saved");
+          cachedEditorConfigStorage.saveConfig(List.of(key, config.getDocId()), config, false);
+          fireError(status);
+          broadcastEvent(status, OnlyofficeEditorService.EDITOR_ERROR_EVENT);
+          LOG.warn("Received Onlyoffice error of saving document. Key: " + key + ". Users: "
+              + Arrays.toString(status.getUsers()) + ". Error: " + status.getError()
+              + ". Last change was successfully saved for " + nodePath);
         } else {
-          // warn unexpected status, wait for next status
-          LOG.warn("Received Onlyoffice unexpected status. Key: " + key + ". URL: " + status.getUrl() + ". Users: "
-              + status.getUsers() + ". Document: " + nodePath);
+          LOG.warn("Received Onlyoffice error of saving document without changes URL. Key: " + key + ". Users: "
+              + Arrays.toString(status.getUsers()) + ". Document: " + nodePath + ". Error: " + status.getError());
+          config.setError("Error in editor (" + status.getError() + "). No changes saved");
+          cachedEditorConfigStorage.saveConfig(List.of(key, config.getDocId()), config,false);
+          fireError(status);
+          broadcastEvent(status, OnlyofficeEditorService.EDITOR_ERROR_EVENT);
         }
       } else {
-        throw new BadParameterException("User editor not found " + status.getUserId());
+        LOG.warn("Received Onlyoffice error of saving document with several editors. Key: " + key + ". Users: "
+            + Arrays.toString(status.getUsers()) + ". Document: " + nodePath);
+        config.setError("Error in editor. Document still in editing state");
+        cachedEditorConfigStorage.saveConfig(List.of(key, config.getDocId()), config,false);
+        fireError(status);
+        broadcastEvent(status, OnlyofficeEditorService.EDITOR_ERROR_EVENT);
       }
+    } else if (statusCode == 4) {
+      syncUsers(configs, safeUsers(status));
+      closeConfigs(key, configs);
+    } else if (statusCode == 6) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Received Onlyoffice forced saved document. Key: " + key + ". Users: " + Arrays.toString(status.getUsers())
+            + ". Document " + nodePath + ". URL: " + status.getUrl() + ". Download: " + status.isSaved());
+      }
+      if (status.saved == null || status.isSaved()) {
+        LOG.debug("Document is save, and we need to download it (Node (id={}), userId={})",
+                    status.getConfig().getDocId(), status.getUserId());
+        downloadVersion(status);
+      } else {
+        saveLink(status.getUserId(), key, status.getUrl());
+      }
+
+    } else if (statusCode == 7) {
+      LOG.error("Received Onlyoffice error of forced saving of document. Key: " + key + ". Users: "
+          + Arrays.toString(status.getUsers()) + ". Document: " + nodePath + ". Error: " + status.getError() + ". URL: "
+          + status.getUrl() + ". Download: " + status.isSaved());
     } else {
-      throw new BadParameterException("File key not found " + key);
+      LOG.warn("Received Onlyoffice unexpected status. Key: " + key + ". URL: " + status.getUrl() + ". Users: "
+          + status.getUsers() + ". Document: " + nodePath);
     }
   }
 
@@ -1449,9 +1504,14 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     Config config = null;
     try {
       config = getEditorByKey(userId, key);
+      if (config == null) {
+        LOG.warn("Cannot download OnlyOffice version: config not found. userId: " + userId + ", key: " + key);
+        return;
+      }
       docId = config.getDocId();
     } catch (RepositoryException | OnlyofficeEditorException e) {
       LOG.error("Cannot obtain config. docId: " + docId, e);
+      return;
     }
     DocumentStatus status = new DocumentStatus.Builder().config(config)
                                                         .key(key)
@@ -1686,17 +1746,6 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
   }
 
   @Override
-  public void closeWithoutModification(String userId, String key) {
-    Map<String, Config> configs = cachedEditorConfigStorage.getConfigsByKey(key);
-    if (configs.keySet().size()>1) {
-      Config config = configs.get(userId);
-      if (config!=null && config.isClosed()) {
-        cachedEditorConfigStorage.deleteConfig(key, config);
-      }
-    }
-  }
-
-  @Override
   public boolean isDocumentCoedited(String key) {
     Map<String, Config> configs = cachedEditorConfigStorage.getConfigsByKey(key);
     return configs != null && !configs.isEmpty() && configs.size() > 1;
@@ -1737,7 +1786,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       download(status);
       config.getEditorConfig().getUser().setLastSaved(System.currentTimeMillis());
       config.closed(); // reset transient closing state
-      cachedEditorConfigStorage.deleteConfig(List.of(config.getDocument().getKey(),config.getDocId()),config);
+      cachedEditorConfigStorage.saveConfig(List.of(config.getDocument().getKey(), config.getDocId()), config, false);
     } catch (OnlyofficeEditorException | RepositoryException e) {
       LOG.error("Error occured while downloading document content [Closed]. docId: " + config.getDocId(), e);
     }
@@ -1838,7 +1887,11 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
                   .getString();
       }
     } catch (RepositoryException e) {
-      LOG.error(e.getMessage(), e);
+      if (LOG.isDebugEnabled()) {
+        LOG.warn("Error while retrieving the mimetype of node {}. Return empty mimetype. Error: {}", node, e.getMessage());
+      } else {
+        LOG.warn("Error while retrieving the mimetype of node {}. Return empty mimetype.", node, e);
+      }
     }
     return "";
   }
@@ -2005,7 +2058,8 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       config.getEditorConfig().getUser().setLastSaved(System.currentTimeMillis());
       updateCache(config);
     } catch (RepositoryException | OnlyofficeEditorException e) {
-      LOG.error("Error occured while downloading document [Version]. docId: " + status.getConfig().getDocId(), e);
+      Config config = status.getConfig();
+      LOG.error("Error occured while downloading document [Version]. docId: " + (config != null ? config.getDocId() : null), e);
     }
   }
 

--- a/services/src/main/java/org/exoplatform/onlyoffice/cometd/CometdOnlyofficeService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/cometd/CometdOnlyofficeService.java
@@ -551,7 +551,7 @@ public class CometdOnlyofficeService implements Startable {
         // Sometimes the number of users equals 1, even if it's the last
         // user. In that case the Command Service will respond with error 3,
         // and we just ignore it
-        if (users.length > 0) {
+        if (users.length > 0 && lastUser != null) {
           if (lastUser.getLinkSaved() >= lastUser.getLastModified()) {
             if (LOG.isDebugEnabled()) {
               LOG.debug("Downloading from existing link. User: {}, Key: {}, Link: {}",
@@ -590,6 +590,10 @@ public class CometdOnlyofficeService implements Startable {
       }
 
       Editor.User user = editors.getUser(key, userId);
+      if (user == null) {
+        LOG.warn("Cannot handle document version event: user config not found. User: {}, Key: {}", userId, key);
+        return;
+      }
       if (user.getLinkSaved() >= user.getLastModified()) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Downloading from existing link. User: {}, Key: {}, Link: {}", user.getId(), key, user.getDownloadLink());

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/EditorConfigDAO.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/EditorConfigDAO.java
@@ -9,5 +9,7 @@ public interface EditorConfigDAO extends GenericDAO<EditorConfigEntity,Long> {
 
   List<EditorConfigEntity> getConfigByKey(String key);
   List<EditorConfigEntity> getConfigByDocId(String docId);
+  List<EditorConfigEntity> getActiveConfigByDocId(String docId);
+  List<EditorConfigEntity> getClosedConfigBefore(long expirationTime);
 
 }

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/EditorConfigStorage.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/EditorConfigStorage.java
@@ -9,6 +9,9 @@ public interface EditorConfigStorage {
 
   Map<String,Config> getConfigsByKey(String key);
   Map<String,Config> getConfigsByDocId(String docId);
+  Map<String,Config> getActiveConfigsByDocId(String docId);
+  List<Config> getClosedConfigsBefore(long expirationTime);
+  int deleteClosedConfigsBefore(long expirationTime);
   void saveConfig(String key, Config config, boolean isNew);
   void saveConfig(List<String> keys, Config config, boolean isNew);
   void deleteConfig(String key, Config config);

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/dao/EditorConfigDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/dao/EditorConfigDAOImpl.java
@@ -24,4 +24,20 @@ public class EditorConfigDAOImpl extends GenericDAOJPAImpl<EditorConfigEntity, L
     query.setParameter("docId", docId);
     return query.getResultList();
   }
+  @Override
+  public List<EditorConfigEntity> getActiveConfigByDocId(String docId) {
+    TypedQuery<EditorConfigEntity> query = getEntityManager()
+        .createNamedQuery("EditorConfigEntity.getActiveConfigByDocId",EditorConfigEntity.class);
+    query.setParameter("docId", docId);
+    return query.getResultList();
+  }
+
+  @Override
+  public List<EditorConfigEntity> getClosedConfigBefore(long expirationTime) {
+    TypedQuery<EditorConfigEntity> query = getEntityManager()
+        .createNamedQuery("EditorConfigEntity.getClosedConfigBefore",EditorConfigEntity.class);
+    query.setParameter("expirationTime", expirationTime);
+    return query.getResultList();
+  }
+
 }

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/entities/EditorConfigEntity.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/entities/EditorConfigEntity.java
@@ -16,8 +16,10 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
 @ExoEntity
 @Table(name = "OO_EDITOR_CONFIG")
 @NamedQueries({
-    @NamedQuery(name = "EditorConfigEntity.getConfigByKey", query = "SELECT e FROM EditorConfigEntity e WHERE e.documentKey = :key"),
-    @NamedQuery(name = "EditorConfigEntity.getConfigByDocId", query = "SELECT e FROM EditorConfigEntity e WHERE e.documentId = :docId")
+    @NamedQuery(name = "EditorConfigEntity.getConfigByKey", query = "SELECT e FROM EditorConfigEntity e WHERE e.documentKey = :key ORDER BY e.id DESC"),
+    @NamedQuery(name = "EditorConfigEntity.getConfigByDocId", query = "SELECT e FROM EditorConfigEntity e WHERE e.documentId = :docId ORDER BY e.id DESC"),
+    @NamedQuery(name = "EditorConfigEntity.getActiveConfigByDocId", query = "SELECT e FROM EditorConfigEntity e WHERE e.documentId = :docId AND (e.closedTime IS NULL OR e.open = true OR e.closing = true) ORDER BY e.id DESC"),
+    @NamedQuery(name = "EditorConfigEntity.getClosedConfigBefore", query = "SELECT e FROM EditorConfigEntity e WHERE e.open = false AND e.closing = false AND e.closedTime IS NOT NULL AND e.closedTime < :expirationTime ORDER BY e.id ASC")
 })
 public class EditorConfigEntity {
   @Id

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/cache/CachedEditorConfigStorage.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/cache/CachedEditorConfigStorage.java
@@ -1,75 +1,127 @@
 package org.exoplatform.onlyoffice.jpa.storage.cache;
 
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.cache.future.FutureExoCache;
+import org.exoplatform.commons.cache.future.Loader;
 import org.exoplatform.onlyoffice.Config;
 import org.exoplatform.onlyoffice.jpa.EditorConfigStorage;
 import org.exoplatform.onlyoffice.jpa.storage.impl.RDBMSEditorConfigStorageImpl;
 import org.exoplatform.services.cache.CacheService;
 import org.exoplatform.services.cache.ExoCache;
 
-import java.util.List;
-import java.util.Map;
-
 public class CachedEditorConfigStorage implements EditorConfigStorage {
 
-  private EditorConfigStorage storage;
+  private static final int                                     CONFIG_BY_KEY           = 1;
 
-  private final ExoCache<String, Map<String, Config>> configCache;
+  private static final int                                     CONFIG_BY_DOC_ID        = 2;
 
-  public static final String     CACHE_NAME               = "onlyoffice.EditorCache";
+  private static final int                                     ACTIVE_CONFIG_BY_DOC_ID = 3;
 
+  private EditorConfigStorage                                  storage;
+
+  private FutureExoCache<String, Map<String, Config>, Integer> futureCache;
+
+  public static final String                                   CACHE_NAME              = "onlyoffice.EditorCache";
 
   public CachedEditorConfigStorage(final RDBMSEditorConfigStorageImpl storage, CacheService cacheService) {
     this.storage = storage;
-    configCache = cacheService.getCacheInstance(CACHE_NAME);
+    ExoCache<String, Map<String, Config>> configCache = cacheService.getCacheInstance(CACHE_NAME);
+    Loader<String, Map<String, Config>, Integer> loader = new Loader<>() {
+      @Override
+      public Map<String, Config> retrieve(Integer context, String key) throws Exception {
+        return switch (context) {
+        case CONFIG_BY_KEY -> storage.getConfigsByKey(key);
+        case CONFIG_BY_DOC_ID -> storage.getConfigsByDocId(key);
+        case ACTIVE_CONFIG_BY_DOC_ID -> storage.getActiveConfigsByDocId(key);
+        default -> null;
+        };
+      }
+    };
+    this.futureCache = new FutureExoCache<>(loader, configCache);
+
   }
 
   @Override
   public Map<String, Config> getConfigsByKey(String key) {
-    Map<String, Config> configs = configCache.get(key);
-    if (configs != null && !configs.isEmpty()) {
-      return configs;
-    }
-    configs = storage.getConfigsByKey(key);
-    if (configs != null && !configs.isEmpty()) {
-      configCache.put(key, configs);
-    }
-    return configs;
+    return futureCache.get(CONFIG_BY_KEY, key);
   }
 
   @Override
   public Map<String, Config> getConfigsByDocId(String docId) {
-    Map<String, Config> configs = configCache.get(docId);
-    if (configs != null && !configs.isEmpty()) {
-      return configs;
+    return futureCache.get(CONFIG_BY_DOC_ID, docId);
+  }
+
+  @Override
+  public Map<String, Config> getActiveConfigsByDocId(String docId) {
+    return futureCache.get(ACTIVE_CONFIG_BY_DOC_ID, docId);
+  }
+
+  @Override
+  public List<Config> getClosedConfigsBefore(long expirationTime) {
+    return storage.getClosedConfigsBefore(expirationTime);
+  }
+
+  @Override
+  public int deleteClosedConfigsBefore(long expirationTime) {
+    List<Config> expiredConfigs = storage.getClosedConfigsBefore(expirationTime);
+    int deleted = storage.deleteClosedConfigsBefore(expirationTime);
+    if (CollectionUtils.isNotEmpty(expiredConfigs)) {
+      expiredConfigs.forEach(config -> {
+        if (config != null) {
+          futureCache.remove(config.getDocument().getKey());
+          futureCache.remove(config.getDocId());
+        }
+      });
     }
-    configs = storage.getConfigsByDocId(docId);
-    if (configs != null && !configs.isEmpty()) {
-      configCache.put(docId, configs);
-    }
-    return configs;
+    return deleted;
   }
 
   @Override
   public void saveConfig(String key, Config config, boolean isNew) {
-    storage.saveConfig(key,config,isNew);
-    configCache.remove(key);
+    try {
+      storage.saveConfig(key, config, isNew);
+    } finally {
+      futureCache.remove(key);
+    }
   }
 
   @Override
   public void saveConfig(List<String> keys, Config config, boolean isNew) {
-    storage.saveConfig(keys,config,isNew);
-    keys.forEach(configCache::remove);
+    if (CollectionUtils.isNotEmpty(keys)) {
+      try {
+        storage.saveConfig(keys, config, isNew);
+      } finally {
+        keys.stream()
+            .filter(StringUtils::isNotBlank)
+            .forEach(futureCache::remove);
+      }
+    }
   }
 
   @Override
   public void deleteConfig(String key, Config config) {
-    storage.deleteConfig(key,config);
-    configCache.remove(key);
+    try {
+      storage.deleteConfig(key, config);
+    } finally {
+      futureCache.remove(key);
+    }
   }
 
   @Override
   public void deleteConfig(List<String> keys, Config config) {
-    storage.deleteConfig(keys,config);
-    keys.forEach(configCache::remove);
+    if (CollectionUtils.isNotEmpty(keys)) {
+      try {
+        storage.deleteConfig(keys, config);
+      } finally {
+        keys.stream()
+            .filter(StringUtils::isNotBlank)
+            .forEach(futureCache::remove);
+      }
+    }
   }
 }

--- a/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/impl/RDBMSEditorConfigStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/jpa/storage/impl/RDBMSEditorConfigStorageImpl.java
@@ -44,6 +44,30 @@ public class RDBMSEditorConfigStorageImpl implements EditorConfigStorage {
                                                        (key1, key2) -> key1));
   }
 
+  @Override
+  @ExoTransactional
+  public Map<String,Config> getActiveConfigsByDocId(String docId) {
+    List<EditorConfigEntity> entities = editorConfigDAO.getActiveConfigByDocId(docId);
+    return entities.stream()
+                   .collect(Collectors.toConcurrentMap(EditorConfigEntity::getEditorUserUserid,
+                                                       this::buildFromEntity,
+                                                       (key1, key2) -> key1));
+  }
+
+  @Override
+  @ExoTransactional
+  public List<Config> getClosedConfigsBefore(long expirationTime) {
+    List<EditorConfigEntity> entities = editorConfigDAO.getClosedConfigBefore(expirationTime);
+    return entities.stream().map(this::buildFromEntity).collect(Collectors.toList());
+  }
+
+  @Override
+  @ExoTransactional
+  public int deleteClosedConfigsBefore(long expirationTime) {
+    List<EditorConfigEntity> entities = editorConfigDAO.getClosedConfigBefore(expirationTime);
+    entities.forEach(editorConfigDAO::delete);
+    return entities.size();
+  }
 
 
   @Override
@@ -176,10 +200,18 @@ public class RDBMSEditorConfigStorageImpl implements EditorConfigStorage {
     Config result = builder.build();
     result.setError(entity.getError());
     result.setDatabaseId(entity.getId());
-    result.setOpen(entity.isOpen());
-    result.setClosing(entity.isClosing());
     result.setOpenedTime(entity.getOpenedTime());
     result.setClosedTime(entity.getClosedTime());
+    if (entity.isOpen()) {
+      result.setOpen(true);
+      result.setClosing(false);
+    } else if (entity.isClosing()) {
+      result.setOpen(false);
+      result.setClosing(true);
+    } else if (entity.getClosedTime() != null) {
+      result.setOpen(false);
+      result.setClosing(false);
+    }
 
     result.getEditorConfig().getUser().setLastModified(entity.getEditorUserLastModified());
     result.getEditorConfig().getUser().setLastSaved(entity.getEditorUserLastSaved());

--- a/services/src/main/java/org/exoplatform/onlyoffice/rest/EditorService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/rest/EditorService.java
@@ -254,7 +254,11 @@ public class EditorService implements ResourceContainer {
                 editors.updateDocument(statusBuilder.build());
                 resp.entity("{\"error\": 0}");
               } catch (BadParameterException e) {
-                LOG.warn("Bad parameter to update status for " + key + ". " + e.getMessage());
+                if (LOG.isDebugEnabled()) {
+                  LOG.warn("Bad parameter to update status for {}. ", key, e);
+                } else {
+                  LOG.warn("Bad parameter to update status for {}. Error: {}", key, e.getMessage());
+                }
                 resp.error(e.getMessage()).status(Status.BAD_REQUEST);
               } catch (OnlyofficeEditorException e) {
                 LOG.error("Error handling status for " + key, e);
@@ -329,7 +333,11 @@ public class EditorService implements ResourceContainer {
               resp.error("User not provided").status(Status.BAD_REQUEST);
             }
           } catch (BadParameterException e) {
-            LOG.warn("Bad parameter to downloading content for " + key + ". " + e.getMessage());
+            if (LOG.isDebugEnabled()) {
+              LOG.warn("Bad parameter to downloading content for {}. ", key, e);
+            } else {
+              LOG.warn("Bad parameter to downloading content for {}. Error: {}", key, e.getMessage());
+            }
             resp.error(e.getMessage()).status(Status.BAD_REQUEST);
           } catch (OnlyofficeEditorException e) {
             LOG.error("Error downloading content for " + key, e);
@@ -441,7 +449,11 @@ public class EditorService implements ResourceContainer {
             resp.error("User not authenticated").status(Status.UNAUTHORIZED);
           }
         } catch (BadParameterException e) {
-          LOG.warn("Bad parameter for creating editor config " + workspace + ":" + path + ". " + e.getMessage());
+          if (LOG.isDebugEnabled()) {
+            LOG.warn("Bad parameter for creating editor config {}:{}. ", workspace, path, e);
+          } else {
+            LOG.warn("Bad parameter for creating editor config {}:{}. Error: {}", workspace, path, e.getMessage());
+          }
           resp.error(e.getMessage()).status(Status.BAD_REQUEST);
         } catch (OnlyofficeEditorException e) {
           LOG.error("Error creating editor config " + workspace + ":" + path, e);
@@ -511,7 +523,11 @@ public class EditorService implements ResourceContainer {
           ChangeState status = editors.getState(userId, key);
           resp.entity(status).ok();
         } catch (BadParameterException e) {
-          LOG.warn("Bad parameter for getting document state " + userId + "@" + key + ". " + e.getMessage());
+          if (LOG.isDebugEnabled()) {
+            LOG.warn("Bad parameter for creating editor config userId = {}, key = {}.", userId, key, e);
+          } else {
+            LOG.warn("Bad parameter for creating editor config userId = {}, key = {}. Error: {}", userId, key, e.getMessage());
+          }
           resp.error(e.getMessage()).status(Status.BAD_REQUEST);
         } catch (OnlyofficeEditorException e) {
           LOG.error("Error getting document state " + userId + "@" + key, e);
@@ -684,7 +700,11 @@ public class EditorService implements ResourceContainer {
           return host;
         }
       } catch (Exception e) {
-        LOG.warn("Cannot obtain client hostname by its IP " + clientIp + ": " + e.getMessage());
+        if (LOG.isDebugEnabled()) {
+          LOG.warn("Cannot obtain client hostname by its IP {}", clientIp, e);
+        } else {
+          LOG.warn("Cannot obtain client hostname by its IP {}. Error: ", clientIp, e.getMessage());
+        }
       }
     }
     host = request.getRemoteHost();

--- a/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
+++ b/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
@@ -1093,11 +1093,10 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     editorService.updateDocument(status);
 
     // Then
-    assertNull(editorService.getEditorByKey(USER_USERNAME,documentKey));
-
-//    assertTrue(config.isClosed());
-//    assertFalse(config.isOpen());
-//    assertNotSame(config.getEditorConfig().getUser().getLastSaved(), 0);
+    Config retainedConfig = editorService.getEditorByKey(USER_USERNAME, documentKey);
+    assertNotNull(retainedConfig);
+    assertTrue(retainedConfig.isClosed());
+    assertFalse(retainedConfig.isOpen());
     node.remove();
   }
 
@@ -1282,7 +1281,268 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     editorService.updateDocument(status);
 
     Config result = editorService.getEditorByKey(USER_USERNAME,config.getDocument().getKey());
-    assertNull(result);
+    assertNotNull(result);
+    assertTrue(result.isClosed());
+    assertFalse(result.isOpen());
+    node.remove();
+  }
+
+
+  /**
+   * Test late status 2 after status 4. The config must remain resolvable by key
+   * during the grace period so a late final-save callback does not fail with
+   * File key not found.
+   */
+  @Test
+  public void testLateFinalSaveAfterClosedWithoutChangesKeepsConfigResolvable() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Config config = editorService.createEditor("http", "127.0.0.1", 8080, USER_USERNAME, null, node.getUUID(), OnlyofficeEditorService.EDIT_MODE);
+    String key = config.getDocument().getKey();
+
+    DocumentStatus openStatus = new DocumentStatus.Builder().status(1L)
+                                                            .users(new String[] { USER_USERNAME })
+                                                            .userId(USER_USERNAME)
+                                                            .key(key)
+                                                            .build();
+    editorService.updateDocument(openStatus);
+
+    DocumentStatus closedStatus = new DocumentStatus.Builder().status(4L)
+                                                              .users(new String[] {})
+                                                              .userId(USER_USERNAME)
+                                                              .key(key)
+                                                              .build();
+    editorService.updateDocument(closedStatus);
+
+    Config closedConfig = editorService.getEditorByKey(USER_USERNAME, key);
+    assertNotNull(closedConfig);
+    assertTrue(closedConfig.isClosed());
+
+    DocumentStatus lateFinalStatus = new DocumentStatus.Builder().status(2L)
+                                                                 .users(new String[] { USER_USERNAME })
+                                                                 .userId(USER_USERNAME)
+                                                                 .key(key)
+                                                                 .build();
+    editorService.updateDocument(lateFinalStatus);
+
+    Config retainedConfig = editorService.getEditorByKey(USER_USERNAME, key);
+    assertNotNull(retainedConfig);
+    assertTrue(retainedConfig.isClosed());
+    node.remove();
+  }
+
+  /**
+   * Test reopening after a terminal close creates a fresh active key while the
+   * old key remains resolvable for late callbacks.
+   */
+  @Test
+  public void testReopenAfterCloseCreatesNewKeyAndRetainsOldKey() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Config firstConfig = editorService.createEditor("http",
+                                                    "127.0.0.1",
+                                                    8080,
+                                                    USER_USERNAME,
+                                                    null,
+                                                    node.getUUID(),
+                                                    OnlyofficeEditorService.EDIT_MODE);
+    String oldKey = firstConfig.getDocument().getKey();
+
+    DocumentStatus openStatus = new DocumentStatus.Builder().status(1L)
+                                                            .users(new String[] { USER_USERNAME })
+                                                            .userId(USER_USERNAME)
+                                                            .key(oldKey)
+                                                            .build();
+    editorService.updateDocument(openStatus);
+
+    DocumentStatus closedStatus = new DocumentStatus.Builder().status(4L)
+                                                              .users(new String[] {})
+                                                              .userId(USER_USERNAME)
+                                                              .key(oldKey)
+                                                              .build();
+    editorService.updateDocument(closedStatus);
+
+    Config secondConfig = editorService.createEditor("http",
+                                                     "127.0.0.1",
+                                                     8080,
+                                                     USER_USERNAME,
+                                                     null,
+                                                     node.getUUID(),
+                                                     OnlyofficeEditorService.EDIT_MODE);
+    String newKey = secondConfig.getDocument().getKey();
+
+    assertFalse(oldKey.equals(newKey));
+    Config oldConfig = editorService.getEditorByKey(USER_USERNAME, oldKey);
+    assertNotNull(oldConfig);
+    assertTrue(oldConfig.isClosed());
+    assertNotNull(editorService.getEditorByKey(USER_USERNAME, newKey));
+    node.remove();
+  }
+
+  /**
+   * Test a closed config does not block another user from opening the same
+   * document.
+   */
+  @Test
+  public void testClosedConfigDoesNotBlockAnotherUserOpeningDocument() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Config firstConfig = editorService.createEditor("http",
+                                                    "127.0.0.1",
+                                                    8080,
+                                                    USER_USERNAME,
+                                                    null,
+                                                    node.getUUID(),
+                                                    OnlyofficeEditorService.EDIT_MODE);
+    String oldKey = firstConfig.getDocument().getKey();
+
+    DocumentStatus openStatus = new DocumentStatus.Builder().status(1L)
+                                                            .users(new String[] { USER_USERNAME })
+                                                            .userId(USER_USERNAME)
+                                                            .key(oldKey)
+                                                            .build();
+    editorService.updateDocument(openStatus);
+
+    DocumentStatus closeStatus = new DocumentStatus.Builder().status(4L)
+                                                             .users(new String[] {})
+                                                             .userId(USER_USERNAME)
+                                                             .key(oldKey)
+                                                             .build();
+    editorService.updateDocument(closeStatus);
+
+    Config rootConfig = editorService.createEditor("http",
+                                                   "127.0.0.1",
+                                                   8080,
+                                                   "root",
+                                                   null,
+                                                   node.getUUID(),
+                                                   OnlyofficeEditorService.EDIT_MODE);
+
+    assertNotNull(rootConfig);
+    assertFalse(oldKey.equals(rootConfig.getDocument().getKey()));
+    assertNotNull(editorService.getEditorByKey(USER_USERNAME, oldKey));
+    assertNotNull(editorService.getEditorByKey("root", rootConfig.getDocument().getKey()));
+    node.remove();
+  }
+
+  /**
+   * Test a terminal callback without a usable user id can resolve the only
+   * config for the key.
+   */
+  @Test
+  public void testTerminalCallbackWithoutUserIdFallsBackToOnlyConfig() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
+    String key = config.getDocument().getKey();
+
+    DocumentStatus status = new DocumentStatus.Builder().status(4L)
+                                                        .users(new String[] {})
+                                                        .key(key)
+                                                        .build();
+    editorService.updateDocument(status);
+
+    Config closedConfig = editorService.getEditorByKey(USER_USERNAME, key);
+    assertNotNull(closedConfig);
+    assertTrue(closedConfig.isClosed());
+    node.remove();
+  }
+
+  /**
+   * Test duplicate terminal final-save callbacks are idempotent and keep the
+   * key resolvable.
+   */
+  @Test
+  public void testDuplicateFinalSaveCallbackIsIdempotent() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
+    String key = config.getDocument().getKey();
+
+    DocumentStatus status = new DocumentStatus.Builder().status(2L)
+                                                        .users(new String[] { USER_USERNAME })
+                                                        .userId(USER_USERNAME)
+                                                        .key(key)
+                                                        .build();
+    editorService.updateDocument(status);
+    editorService.updateDocument(status);
+
+    Config retainedConfig = editorService.getEditorByKey(USER_USERNAME, key);
+    assertNotNull(retainedConfig);
+    assertTrue(retainedConfig.isClosed());
+    node.remove();
+  }
+
+  /**
+   * Test status 3 with a content URL retains the config and persists the
+   * recovery error.
+   */
+  @Test
+  public void testSavingErrorWithContentUrlRetainsConfigAndPersistsError() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
+    String key = config.getDocument().getKey();
+
+    DocumentStatus status = new DocumentStatus.Builder().status(3L)
+                                                        .users(new String[] { USER_USERNAME })
+                                                        .userId(USER_USERNAME)
+                                                        .url("http://127.0.0.1:8080/editor/")
+                                                        .key(key)
+                                                        .build();
+    editorService.updateDocument(status);
+
+    Config retainedConfig = editorService.getEditorByKey(USER_USERNAME, key);
+    assertNotNull(retainedConfig);
+    assertNotNull(retainedConfig.getError());
+    assertEquals("Error in editor (0). Last change was successfully saved", retainedConfig.getError());
+    node.remove();
+  }
+
+  /**
+   * Test local state after soft close reports saved with no active users.
+   */
+  @Test
+  public void testGetStateAfterSoftCloseReportsSaved() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Test Document.docx", "nt:file", "testContent", true);
+    Config config = editorService.createEditor("http",
+                                               "127.0.0.1",
+                                               8080,
+                                               USER_USERNAME,
+                                               null,
+                                               node.getUUID(),
+                                               OnlyofficeEditorService.EDIT_MODE);
+    String key = config.getDocument().getKey();
+
+    DocumentStatus closeStatus = new DocumentStatus.Builder().status(4L)
+                                                             .users(new String[] {})
+                                                             .userId(USER_USERNAME)
+                                                             .key(key)
+                                                             .build();
+    editorService.updateDocument(closeStatus);
+
+    ChangeState state = editorService.getState(USER_USERNAME, key);
+    assertTrue(state.isSaved());
+    assertEquals(0, state.getUsers().length);
     node.remove();
   }
 


### PR DESCRIPTION
Avoid deleting OnlyOffice editor configs immediately on terminal callback statuses. Closed configs are now retained for a grace period so late or retried callbacks can still resolve the document key.

Introduce active config lookup by document id so closed configs do not block reopening the same document with a new OnlyOffice key.

Also harden callback resolution, status handling, and CometD flows against missing user/config state, and add regression tests for close/reopen, late callbacks, duplicate terminal callbacks, and status error handling.