### PR TITLE
fix: Avoid having an error when adding a document using WebDav Thread - EXO-88503

### DIFF
--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -2540,6 +2540,12 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
    */
   protected Node node(String workspace, String path) throws BadParameterException, RepositoryException {
     SessionProvider sp = sessionProviders.getSessionProvider(null);
+    if (sp == null) {
+      LOG.debug("Document '{}:{}' retrieval canceled since no User Session Provider is present",
+                workspace,
+                path);
+      return null;
+    }
     Session userSession = sp.getSession(workspace, jcrService.getCurrentRepository());
 
     Item item = finder.findItem(userSession, path);


### PR DESCRIPTION
Prior to this change, when using WebDav URL, the ThreadLocalSessionProviderService doesn't hold any User SessionProvider in the ThreadLocal. This change will simply avoid updating OO activity stream item since it's not related to Activities when updating a document through WebDav.