### PR TITLE
feat: OnlyOffice office MCP tools (edit/generate/convert/export) + attachment images - EXO-88456

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,8 @@
   <properties>
     <!-- eXo Modules -->
     <addon.exo.ecms.version>7.3.x-SNAPSHOT</addon.exo.ecms.version>
-  
+    <addon.exo.documents.version>7.3.x-SNAPSHOT</addon.exo.documents.version>
+
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
   </properties>
@@ -56,6 +57,16 @@
         <groupId>org.exoplatform.ecms</groupId>
         <artifactId>ecms</artifactId>
         <version>${addon.exo.ecms.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Documents add-on: DocumentFileService is reused to store the
+           converted office / PDF bytes in the user's drive (import path). -->
+      <dependency>
+        <groupId>org.exoplatform.documents</groupId>
+        <artifactId>documents-parent</artifactId>
+        <version>${addon.exo.documents.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -104,6 +104,22 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Documents add-on API: DocumentFileService is reused to store the
+         converted office / PDF bytes in the user's drive (import path). -->
+    <dependency>
+      <groupId>org.exoplatform.documents</groupId>
+      <artifactId>documents-api</artifactId>
+      <version>7.3.x-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- MCP Server API, used by the ONLYOFFICE MCP tools exposed to the AI agent. -->
+    <dependency>
+      <groupId>io.meeds.mcp-server</groupId>
+      <artifactId>mcp-server-tools</artifactId>
+      <version>7.3.x-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- For tests -->
     <dependency>
       <groupId>io.meeds.social</groupId>
@@ -129,6 +145,7 @@
         <includes>
           <include>**/*.properties</include>
           <include>**/*.xml</include>
+          <include>**/*.json</include>
           <include>**/*.drl</include>
           <include>**/*.doc</include>
           <include>**/*.xls</include>
@@ -152,6 +169,16 @@
     </resources>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <!-- Required so MCP tool method parameter names are retained and bound by name -->
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.openapitools.swagger</groupId>
         <artifactId>swagger-maven-plugin</artifactId>
@@ -180,6 +207,7 @@
           <includes>
             <include>**/**/EditorServiceTest.java</include>
             <include>**/**/OnlyofficeEditorServiceTest.java</include>
+            <include>**/**/OnlyofficeMcpToolTest.java</include>
           </includes>
         </configuration>
       </plugin>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -109,14 +109,12 @@
     <dependency>
       <groupId>org.exoplatform.documents</groupId>
       <artifactId>documents-api</artifactId>
-      <version>7.3.x-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <!-- MCP Server API, used by the ONLYOFFICE MCP tools exposed to the AI agent. -->
     <dependency>
       <groupId>io.meeds.mcp-server</groupId>
       <artifactId>mcp-server-tools</artifactId>
-      <version>7.3.x-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorService.java
@@ -19,6 +19,7 @@
 package org.exoplatform.onlyoffice;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -408,4 +409,60 @@ public interface OnlyofficeEditorService {
    */
 
   byte[] convertNodeContent(Node node, String format, String originalFileType, String userId);
+
+  /**
+   * Runs an ONLYOFFICE Document Server <b>Document Builder</b> script and returns
+   * the produced native office file (docx / xlsx / pptx / pdf) bytes. This is the
+   * single, shared, security-critical primitive used by the office MCP tools to
+   * both CREATE ({@code builder.CreateFile}) and MODIFY ({@code builder.OpenFile})
+   * documents.
+   * <p>
+   * <b>Trust model.</b> The script and every referenced asset (the existing file
+   * being modified, images) are staged in an in-memory, single-use registry and
+   * served to the (remote) Document Server through the SAME host-restricted
+   * ({@code canDownloadBy}) and JWT-guarded ({@code validateToken})
+   * {@code /onlyoffice/editor/content/{userId}/{key}} endpoint used for
+   * editing/conversion, at URLs built from {@code exo.base.url} (never a request
+   * host). Keys are unguessable, entries are removed on first fetch and expire
+   * after {@value OnlyofficeEditorServiceImpl#DOCBUILDER_ASSET_TTL_MS} ms; there
+   * is no path traversal (keys are opaque) and no new / unauthenticated file
+   * endpoint. The Document Server signs its own {@code Authorization} header when
+   * it fetches the script URL; in-script asset URLs (which the server fetches
+   * without a header) carry a signed {@code token} query parameter that
+   * {@code validateToken} accepts.
+   * <p>
+   * The script must reference each asset by an {@code @@ASSET:<name>@@}
+   * placeholder (matching a key of {@code assets}); every placeholder is replaced
+   * with the asset's short-lived, token-guarded URL before the script is run.
+   *
+   * @param scriptBody the Document Builder script, referencing assets by
+   *          {@code @@ASSET:<name>@@} placeholders
+   * @param assets the assets referenced by the script (name to bytes); may be
+   *          {@code null} or empty for a pure CREATE script
+   * @param outputFormat the produced format, e.g. {@code docx}, {@code xlsx},
+   *          {@code pptx}, {@code pdf} (used for error messages)
+   * @param outputName the {@code builder.SaveFile} output name to download from
+   *          the response; the first produced file is used when {@code null}
+   * @param userId the acting user name (used only to shape the content URL)
+   * @return the produced document bytes (never {@code null})
+   * @throws IllegalStateException on any Document Server failure, with an
+   *           LLM-directed message
+   */
+  byte[] runDocBuilderScript(String scriptBody,
+                             Map<String, byte[]> assets,
+                             String outputFormat,
+                             String outputName,
+                             String userId);
+
+  /**
+   * Writes new content onto an existing document node (as the current user) and
+   * creates a new version, so a Document Builder MODIFY result is saved as a new
+   * version of the source file.
+   *
+   * @param node the existing document node (resolved in the user's session)
+   * @param content the new file bytes
+   * @param userId the acting user name, stored as last modifier
+   * @throws RepositoryException on a storage error
+   */
+  void saveNewVersion(Node node, byte[] content, String userId) throws RepositoryException;
 }

--- a/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceImpl.java
@@ -19,6 +19,7 @@
 package org.exoplatform.onlyoffice;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -395,6 +397,26 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
 
   protected final String                                          convertUrl;
 
+  /** The ONLYOFFICE Document Builder (docbuilder) HTTP API url. */
+  protected final String                                          docbuilderUrl;
+
+  /**
+   * Time-to-live of a short-lived, single-use asset staged in-memory to be
+   * fetched by the Document Server during a Document Builder run (script, the
+   * existing file being modified, images).
+   */
+  protected static final long                                     DOCBUILDER_ASSET_TTL_MS = 120000L;
+
+  /**
+   * In-memory registry of short-lived, single-use assets served to the Document
+   * Server for Document Builder runs, keyed by an unguessable random key. Each
+   * entry is removed on first fetch (single-use) or when it expires, and is
+   * served through the SAME host-restricted, {@code validateToken}-guarded
+   * {@code /onlyoffice/editor/content/{userId}/{key}} endpoint as the editor
+   * content (no new / unauthenticated file endpoint is introduced).
+   */
+  protected final Map<String, StagedAsset>                        docBuilderAssets        = new ConcurrentHashMap<>();
+
   /** The document server secret. */
   protected final String                                          documentserverSecret;
 
@@ -499,6 +521,7 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
     this.convertUrl = new StringBuilder(documentserverUrl).append("/converter").toString();
     this.documentserverUrl = new StringBuilder(documentserverUrl).append("/web-apps/").toString();
     this.commandServiceUrl = new StringBuilder(documentserverUrl).append("/coauthoring/CommandService.ashx").toString();
+    this.docbuilderUrl = new StringBuilder(documentserverUrl).append("/docbuilder").toString();
     this.documentserverAccessOnly = Boolean.parseBoolean(config.get(CONFIG_DS_ACCESS_ONLY));
     this.documentserverSecret = config.get(CONFIG_DS_SECRET);
     this.documentserverAllowedhosts = getDocumentserverAllowedHosts(config.get(CONFIG_DS_ALLOWEDHOSTS));
@@ -868,6 +891,30 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
    */
   @Override
   public DocumentContent getContent(String userId, String key) throws OnlyofficeEditorException, RepositoryException {
+    // Document Builder assets (script / existing file / images) are staged
+    // in-memory and served through this same endpoint. They are single-use:
+    // removed on first fetch. The host restriction and token validation are
+    // enforced by the REST layer (canDownloadBy + validateToken) before we get
+    // here, exactly as for the editor content below.
+    StagedAsset staged = docBuilderAssets.remove(key);
+    if (staged != null) {
+      if (System.currentTimeMillis() > staged.expiresAt) {
+        throw new BadParameterException("Document Builder asset expired or already consumed: " + key);
+      }
+      final String stagedMime = staged.mimeType;
+      final InputStream stagedData = new ByteArrayInputStream(staged.data);
+      return new DocumentContent() {
+        @Override
+        public String getType() {
+          return stagedMime;
+        }
+
+        @Override
+        public InputStream getData() {
+          return stagedData;
+        }
+      };
+    }
     Map<String, Config> configs = cachedEditorConfigStorage.getConfigsByKey(key);
     boolean viewMode = false;
     if (configs == null || configs.isEmpty()) {
@@ -3546,6 +3593,328 @@ public class OnlyofficeEditorServiceImpl implements OnlyofficeEditorService, Sta
       }
     }
     return null;
+  }
+
+  @Override
+  public byte[] runDocBuilderScript(String scriptBody,
+                                    Map<String, byte[]> assets,
+                                    String outputFormat,
+                                    String outputName,
+                                    String userId) {
+    if (scriptBody == null || scriptBody.trim().isEmpty()) {
+      throw new IllegalArgumentException("The Document Builder script is empty; nothing to run.");
+    }
+    String base = System.getProperty("exo.base.url");
+    if (base == null || base.trim().isEmpty()) {
+      throw new IllegalStateException("The platform base URL (exo.base.url) is not configured, so the Document Server "
+          + "cannot fetch the Document Builder script and assets. Configure exo.base.url to a URL the Document Server can reach.");
+    }
+    if (base.endsWith("/")) {
+      base = base.substring(0, base.length() - 1);
+    }
+    String rest = PortalContainer.getCurrentRestContextName();
+    String uid = (userId == null || userId.trim().isEmpty()) ? "null" : userId;
+    long expiresAt = System.currentTimeMillis() + DOCBUILDER_ASSET_TTL_MS;
+    List<String> stagedKeys = new ArrayList<>();
+    try {
+      // 1) Stage every referenced asset (existing file to modify, images) and
+      // substitute its @@ASSET:<name>@@ placeholder with a short-lived, single-use,
+      // token-guarded URL. The Document Server fetches in-script URLs WITHOUT an
+      // Authorization header, so the signed token is carried as a query parameter
+      // that the content endpoint validates through validateToken.
+      String resolvedScript = scriptBody;
+      if (assets != null) {
+        for (Map.Entry<String, byte[]> entry : assets.entrySet()) {
+          String name = entry.getKey();
+          byte[] data = entry.getValue();
+          if (data == null) {
+            continue;
+          }
+          String key = stageDocBuilderAsset(data, mimeForAsset(name), expiresAt);
+          stagedKeys.add(key);
+          String cleanUrl = docBuilderAssetUrl(base, rest, uid, key);
+          String assetUrl = cleanUrl + "?token=" + signKeyToken(key);
+          resolvedScript = resolvedScript.replace("@@ASSET:" + name + "@@", assetUrl);
+        }
+      }
+      // 2) Stage the resolved script itself. The Document Server fetches the
+      // script URL WITH an Authorization: Bearer <jwt payload.url=scriptUrl>
+      // header it signs itself, which validateToken accepts (url endsWith key).
+      String scriptKey = stageDocBuilderAsset(resolvedScript.getBytes(StandardCharsets.UTF_8), "text/plain", expiresAt);
+      stagedKeys.add(scriptKey);
+      String scriptUrl = docBuilderAssetUrl(base, rest, uid, scriptKey);
+      // 3) Run the builder and download the produced file.
+      byte[] result = postDocBuilder(scriptUrl, outputName);
+      if (result == null || result.length == 0) {
+        throw new IllegalStateException("The Document Server ran the Document Builder but returned no file. "
+            + "Verify the operations are valid for a " + outputFormat + " document.");
+      }
+      return result;
+    } finally {
+      // Defensive cleanup: single-use fetch already removes each key; this drops
+      // any asset the Document Server never fetched (e.g. on failure).
+      for (String key : stagedKeys) {
+        docBuilderAssets.remove(key);
+      }
+    }
+  }
+
+  /**
+   * Stages a byte asset in the in-memory registry under a fresh unguessable key
+   * and returns that key. Package-visible for the Document Builder path only.
+   */
+  protected String stageDocBuilderAsset(byte[] data, String mimeType, long expiresAt) {
+    String key = "bldr_" + UUID.randomUUID().toString().replace("-", "");
+    docBuilderAssets.put(key, new StagedAsset(data, mimeType, expiresAt));
+    return key;
+  }
+
+  private String docBuilderAssetUrl(String base, String rest, String userId, String key) {
+    return base + "/" + rest + "/onlyoffice/editor/content/" + userId + "/" + key;
+  }
+
+  /**
+   * Signs a JWT whose {@code payload.key} claim equals the given key, so
+   * {@link #validateToken(String, String)} accepts it (same shape the Document
+   * Server itself emits for the {@code payload.url} case).
+   */
+  private String signKeyToken(String key) {
+    if (documentserverSecret == null || documentserverSecret.trim().isEmpty()) {
+      return "";
+    }
+    Map<String, Object> inner = new HashMap<>();
+    inner.put("key", key);
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("payload", inner);
+    return Jwts.builder().setClaims(claims).signWith(Keys.hmacShaKeyFor(documentserverSecret.getBytes())).compact();
+  }
+
+  private static String mimeForAsset(String name) {
+    String n = name == null ? "" : name.toLowerCase(Locale.ROOT);
+    if (n.endsWith(".png")) {
+      return "image/png";
+    }
+    if (n.endsWith(".jpg") || n.endsWith(".jpeg")) {
+      return "image/jpeg";
+    }
+    if (n.endsWith(".gif")) {
+      return "image/gif";
+    }
+    if (n.endsWith(".docx")) {
+      return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    }
+    if (n.endsWith(".xlsx")) {
+      return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    }
+    if (n.endsWith(".pptx")) {
+      return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    }
+    return "application/octet-stream";
+  }
+
+  /**
+   * POSTs the docbuilder command and downloads the produced file. The request is
+   * signed exactly like {@link #convertNodeContent} (JWT over the request body,
+   * carried both as the {@code token} field and the {@code Authorization} header).
+   */
+  private byte[] postDocBuilder(String scriptUrl, String outputName) {
+    HttpURLConnection connection = null;
+    try {
+      JSONObject body = new JSONObject();
+      body.put("async", false);
+      body.put("url", scriptUrl);
+      String signedJson = body.toString();
+      String token = null;
+      if (documentserverSecret != null && !documentserverSecret.trim().isEmpty()) {
+        token = Jwts.builder().setPayload(signedJson).signWith(Keys.hmacShaKeyFor(documentserverSecret.getBytes())).compact();
+        body.put("token", token);
+      }
+      byte[] postDataBytes = body.toString().getBytes(StandardCharsets.UTF_8);
+
+      URL url = new URL(docbuilderUrl);
+      connection = (HttpURLConnection) url.openConnection();
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+      connection.setRequestProperty("Content-Length", String.valueOf(postDataBytes.length));
+      if (token != null) {
+        connection.setRequestProperty("Authorization", "Bearer " + token);
+      }
+      connection.setDoOutput(true);
+      connection.setDoInput(true);
+      try (OutputStream outputStream = connection.getOutputStream()) {
+        outputStream.write(postDataBytes);
+      }
+      String response;
+      try (InputStream in = new BufferedInputStream(connection.getInputStream())) {
+        response = IOUtils.toString(in, "UTF-8");
+      }
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Document Builder responded: {}", response);
+      }
+      JSONObject responseJson = new JSONObject(response);
+      if (responseJson.has("error")) {
+        throw new IllegalStateException(docBuilderErrorMessage(responseJson.get("error")));
+      }
+      if (responseJson.has("urls")) {
+        JSONObject urls = responseJson.getJSONObject("urls");
+        if (urls.length() > 0) {
+          String fileUrl = null;
+          if (outputName != null && urls.has(outputName)) {
+            fileUrl = urls.getString(outputName);
+          } else {
+            fileUrl = urls.getString(urls.keys().next());
+          }
+          return downloadConvertedFile(fileUrl);
+        }
+      }
+      throw new IllegalStateException("The Document Server produced no output file from the Document Builder script. "
+          + "Raw response: " + response);
+    } catch (IllegalStateException e) {
+      throw e;
+    } catch (Exception e) {
+      LOG.error("Error running the Document Builder", e);
+      throw new IllegalStateException("Could not run the Document Builder on the Document Server: " + e.getMessage());
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
+    }
+  }
+
+  private static String docBuilderErrorMessage(Object errorCode) {
+    String code = String.valueOf(errorCode);
+    String detail;
+    switch (code) {
+      case "-8":
+        detail = "invalid or missing token (JWT). Check the Document Server secret configuration.";
+        break;
+      case "-7":
+        detail = "error reading the request.";
+        break;
+      case "-6":
+        detail = "error while accessing the document builder database.";
+        break;
+      case "-5":
+        detail = "incorrect password / unsupported encrypted document.";
+        break;
+      case "-4":
+        detail = "error while downloading a referenced file (the script, the source document or an image). "
+            + "Verify the asset URLs are reachable from the Document Server.";
+        break;
+      case "-3":
+        detail = "conversion error while building the document.";
+        break;
+      case "-2":
+        detail = "conversion timeout.";
+        break;
+      case "-1":
+        detail = "unknown Document Builder error.";
+        break;
+      default:
+        detail = "error code " + code + ".";
+        break;
+    }
+    return "The Document Server rejected the Document Builder script: " + detail;
+  }
+
+  @Override
+  public void saveNewVersion(Node node, byte[] content, String userId) throws RepositoryException {
+    if (content == null || content.length == 0) {
+      throw new IllegalArgumentException("The new document content is empty; the existing version is left unchanged.");
+    }
+    // node.save() below fires a JCR SessionAction that triggers OnlyOffice's own
+    // DocumentUpdateActivityListener on THIS thread. That handler calls node(...) ->
+    // sessionProviders.getSessionProvider(null), which returns null on an MCP tool
+    // thread (no editor session / no thread-bound SessionProvider), so it NPEs and
+    // aborts the whole modify (edit_document / edit_spreadsheet / edit_presentation
+    // with a document_id). The MCP tool reads/writes through its own private user
+    // SessionProvider and never binds one to the thread-local SessionProviderService,
+    // so bind a provider here (only if the thread has none) for the duration of the
+    // save, and remove it afterwards so we don't leak it onto a pooled thread.
+    SessionProvider previousProvider = sessionProviders.getSessionProvider(null);
+    boolean providerBound = false;
+    if (previousProvider == null) {
+      sessionProviders.setSessionProvider(null, SessionProvider.createSystemProvider());
+      providerBound = true;
+    }
+    try {
+      // A versionable document is left checked-in once a version exists (e.g. after a
+      // previous edit): its subtree is then read-only, so the new bytes must be written
+      // to a checked-out node, otherwise the live/current content stays on the prior
+      // version. Mirror the editor save-back path (see download()), which checks the
+      // node out before updating jcr:data.
+      checkout(node);
+      Node data = nodeContent(node);
+      data.setProperty("jcr:data", new ByteArrayInputStream(content));
+      data.setProperty("jcr:lastModified", Calendar.getInstance());
+      if (node.canAddMixin("exo:modify")) {
+        node.addMixin("exo:modify");
+      }
+      if (userId != null && node.isNodeType("exo:modify")) {
+        node.setProperty("exo:lastModifier", userId);
+        node.setProperty("exo:dateModified", Calendar.getInstance());
+      }
+      node.save();
+      // Evict any cached editor Config for this node so the next open mints a fresh
+      // document key. The editor caches a Config (with its document key) per docId, and
+      // the Document Server caches document content BY that key; an external write here
+      // (edit_document / edit_spreadsheet / edit_presentation on an existing doc) never
+      // invalidates that cache, so reopening the doc would show the pre-edit copy from
+      // the DS while JCR + version history already have the new content. Drop the cached
+      // configs (same eviction used in getEditor when a stale key is detected) to force a
+      // new key -> DS re-fetch -> the editor shows the just-written content.
+      try {
+        String docId = node.getUUID();
+        Map<String, Config> activeConfigs = cachedEditorConfigStorage.getActiveConfigsByDocId(docId);
+        if (activeConfigs != null) {
+          for (Config cfg : activeConfigs.values()) {
+            cachedEditorConfigStorage.deleteConfig(List.of(cfg.getDocument().getKey(), cfg.getDocId()), cfg);
+          }
+        }
+      } catch (Exception e) {
+        LOG.warn("Could not evict the cached editor config for node {} after a Document Builder edit: {}",
+                 node.getPath(),
+                 e.getMessage());
+      }
+      try {
+        // VersionHistoryUtils.createVersion() only snapshots the current live content
+        // into a new base (current) version when the node is already checked out
+        // (checkin + checkout); on a checked-in node it performs a bare checkout and
+        // creates NO version, leaving the displayed content on the previous version.
+        // Ensure the node is checked out first, exactly like the editor save-back path
+        // (download(): "if (checkout(node)) VersionHistoryUtils.createVersion(node)").
+        checkout(node);
+        VersionHistoryUtils.createVersion(node);
+      } catch (Exception e) {
+        // Versioning is best-effort: the new content is already saved on the node.
+        LOG.warn("Could not create a version for node {} after a Document Builder edit: {}",
+                 node.getPath(),
+                 e.getMessage());
+      }
+    } finally {
+      if (providerBound) {
+        sessionProviders.removeSessionProvider(null);
+      }
+    }
+  }
+
+  /**
+   * A short-lived, single-use asset staged in-memory to be fetched by the
+   * Document Server during a Document Builder run.
+   */
+  protected static final class StagedAsset {
+
+    private final byte[] data;
+
+    private final String mimeType;
+
+    private final long   expiresAt;
+
+    protected StagedAsset(byte[] data, String mimeType, long expiresAt) {
+      this.data = data;
+      this.mimeType = mimeType;
+      this.expiresAt = expiresAt;
+    }
   }
 
   private Config createConfigForConversion(String userId, Node node) throws OnlyofficeEditorException, RepositoryException {

--- a/services/src/main/java/org/exoplatform/onlyoffice/mcp/OnlyofficeMcpTool.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/mcp/OnlyofficeMcpTool.java
@@ -1,0 +1,1438 @@
+/*
+ * Copyright (C) 2003-2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.onlyoffice.mcp;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Calendar;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.documents.model.AbstractNode;
+import org.exoplatform.documents.model.DocumentFolderFilter;
+import org.exoplatform.documents.model.FileNode;
+import org.exoplatform.documents.service.DocumentFileService;
+import org.exoplatform.onlyoffice.EditorLinkNotFoundException;
+import org.exoplatform.onlyoffice.OfficeDocumentsThumbnailPlugin;
+import org.exoplatform.onlyoffice.OnlyofficeEditorService;
+import org.exoplatform.onlyoffice.mcp.model.OfficeDocumentModel;
+import org.exoplatform.onlyoffice.mcp.model.OfficeEditorLinkModel;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.attachment.AttachmentService;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.upload.UploadService;
+
+import io.meeds.mcp.server.plugin.McpToolPlugin;
+import io.meeds.mcp.server.tool.util.UploadToolUtils;
+
+/**
+ * MCP tools exposing the ONLYOFFICE editor add-on to the AI agent (EVA). The
+ * core is a symmetric family of operations-based office tools that both CREATE
+ * (no {@code document_id}) and MODIFY (a {@code document_id} is given, saved
+ * back as a new version) native office files through the ONLYOFFICE Document
+ * Server <b>Document Builder</b>:
+ * <ul>
+ * <li>{@code edit_spreadsheet} &rarr; xlsx</li>
+ * <li>{@code edit_presentation} &rarr; pptx</li>
+ * <li>{@code edit_document} &rarr; docx</li>
+ * </ul>
+ * plus {@code generate_document} (template + search/replace merge),
+ * {@code convert_document} (format&rarr;format), {@code export_document_as_pdf}
+ * and {@code get_document_editor_link}.
+ * <p>
+ * Every method acts as the current user: source / target JCR nodes are resolved
+ * through a user {@link SessionProvider} (built from the user's ACL identity),
+ * so document ACLs are enforced. The Document Builder script and its assets are
+ * run through the shared, security-critical
+ * {@link OnlyofficeEditorService#runDocBuilderScript} primitive (see its javadoc
+ * for the trust model). A {@code null}/empty Document Server result is always
+ * translated into an LLM-directed {@link IllegalStateException}.
+ * <p>
+ * <b>operations argument.</b> The nested operations array is accepted as a JSON
+ * <i>string</i> (a JSON array of {@code {"type":...}} objects) because the MCP
+ * argument binder does not reliably bind a nested array; it is parsed
+ * server-side.
+ */
+@Service
+@Profile("mcp-server")
+public class OnlyofficeMcpTool implements McpToolPlugin {
+
+  private static final Log         LOG                = ExoLogger.getExoLogger(OnlyofficeMcpTool.class);
+
+  /** In-app preview URL of a stored file (same shape as the Documents add-on). */
+  public static final String       FILE_URL_FORMAT    = "/portal/dw/documents?documentPreviewId=%s";
+
+  /** EMU (English Metric Units) per point, used by the Document Builder shape/chart geometry. */
+  private static final int         EMU                = 36000;
+
+  /** Max bytes fetched for an image referenced by a URL. */
+  private static final long        MAX_IMAGE_BYTES    = 15L * 1024 * 1024;
+
+  private static final String      CONVERT_FAILED_MSG =
+                                                      "The Document Server could not convert this file. "
+                                                          + "Verify the ONLYOFFICE Document Server is installed and running, "
+                                                          + "and that the source format is supported for this conversion.";
+
+  private static final int         IMPORT_POLL_MAX_ATTEMPTS = 20;
+
+  private static final long        IMPORT_POLL_INTERVAL_MS  = 500L;
+
+  private static final int         IMPORT_POLL_PAGE_SIZE    = 200;
+
+  private final OnlyofficeEditorService onlyofficeEditorService;
+
+  private final DocumentFileService     documentFileService;
+
+  private final IdentityManager         identityManager;
+
+  private final UserACL                 userAcl;
+
+  private final RepositoryService       repositoryService;
+
+  private final UploadService           uploadService;
+
+  private final AttachmentService       attachmentService;
+
+  private final FileService             fileService;
+
+  public OnlyofficeMcpTool(OnlyofficeEditorService onlyofficeEditorService,
+                           DocumentFileService documentFileService,
+                           IdentityManager identityManager,
+                           UserACL userAcl,
+                           RepositoryService repositoryService,
+                           UploadService uploadService,
+                           AttachmentService attachmentService,
+                           FileService fileService) {
+    this.onlyofficeEditorService = onlyofficeEditorService;
+    this.documentFileService = documentFileService;
+    this.identityManager = identityManager;
+    this.userAcl = userAcl;
+    this.repositoryService = repositoryService;
+    this.uploadService = uploadService;
+    this.attachmentService = attachmentService;
+    this.fileService = fileService;
+  }
+
+  // ---------------------------------------------------------------------------
+  // edit_spreadsheet / edit_presentation / edit_document
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Creates or modifies a spreadsheet (xlsx). Pass {@code document_id} to MODIFY
+   * an existing spreadsheet (saved back as a new version), or
+   * {@code parent_folder_id}
+   * and {@code name} to CREATE a new one. The {@code operations} are applied via
+   * the ONLYOFFICE Document Builder.
+   * <p>
+   * Supported operations (a JSON array string):
+   * <ul>
+   * <li>{@code {"type":"set_cells","start":"A1","values":[["Region","Sales"],["North",120]]}}</li>
+   * <li>{@code {"type":"set_formula","cell":"B4","formula":"=SUM(B2:B3)"}}</li>
+   * <li>{@code {"type":"add_chart","chart":"bar|line|pie","range":"Sheet1!$A$1:$B$3","title":"..."}}</li>
+   * <li>{@code {"type":"add_sheet","name":"Q3"}} (subsequent ops target the new sheet)</li>
+   * </ul>
+   *
+   * @param documentId optional JCR uuid of an existing spreadsheet to modify
+   * @param parentFolderId folder id where a new spreadsheet is created (create mode)
+   * @param name new spreadsheet name WITHOUT extension (create mode)
+   * @param operations a JSON array string of spreadsheet operations
+   * @return the created / modified document (id + name)
+   */
+  public OfficeDocumentModel editSpreadsheet(String documentId,
+                                             String parentFolderId,
+                                             String name,
+                                             String operations) throws IllegalAccessException, ObjectNotFoundException {
+    // Spreadsheets have no add_image operation, so no image-attachment source is plumbed.
+    return runEdit("xlsx", documentId, parentFolderId, name, operations, null, null);
+  }
+
+  /**
+   * Creates or modifies a presentation (pptx). Pass {@code document_id} to MODIFY
+   * (saved back as a new version) or {@code parent_folder_id} + {@code name} to
+   * CREATE.
+   * <p>
+   * Supported operations (a JSON array string):
+   * <ul>
+   * <li>{@code {"type":"add_slide","layout":"title|content|closing","title":"...","bullets":["a","b"]}}</li>
+   * <li>{@code {"type":"set_slide","index":0,"title":"...","bullets":[...]}} (replaces the slide content)</li>
+   * <li>{@code {"type":"add_image","slide":1,"url":"https://.../pic.png"}} or {@code {"type":"add_image","slide":1,"document_id":"<uuid>"}}</li>
+   * </ul>
+   * <p>
+   * When the user attaches an image in the EVA chat, the agent injects the
+   * chat-attachment reference into the top-level {@code attachmentObjectType} /
+   * {@code attachmentObjectId} parameters; any {@code add_image} operation that
+   * has neither {@code url} nor {@code document_id} then resolves its bytes from
+   * that attachment (see {@link #resolveImageBytes}).
+   *
+   * @param documentId optional JCR uuid of an existing presentation to modify
+   * @param parentFolderId folder id where a new presentation is created (create mode)
+   * @param name new presentation name WITHOUT extension (create mode)
+   * @param operations a JSON array string of presentation operations
+   * @param attachmentObjectType object type of the EVA chat-attachment image source (auto-filled by the agent)
+   * @param attachmentObjectId object id of the EVA chat-attachment image source (auto-filled by the agent)
+   * @return the created / modified document (id + name)
+   */
+  public OfficeDocumentModel editPresentation(String documentId,
+                                              String parentFolderId,
+                                              String name,
+                                              String operations,
+                                              String attachmentObjectType,
+                                              String attachmentObjectId) throws IllegalAccessException,
+                                                                         ObjectNotFoundException {
+    return runEdit("pptx", documentId, parentFolderId, name, operations, attachmentObjectType, attachmentObjectId);
+  }
+
+  /**
+   * Creates or modifies a text document (docx). Pass {@code document_id} to
+   * MODIFY (saved back as a new version) or {@code parent_folder_id} +
+   * {@code name} to CREATE.
+   * <p>
+   * Supported operations (a JSON array string):
+   * <ul>
+   * <li>{@code {"type":"add_heading","level":1,"text":"..."}}</li>
+   * <li>{@code {"type":"add_paragraph","text":"...","bold":false,"italic":false}}</li>
+   * <li>{@code {"type":"add_table","rows":[["A","B"],["1","2"]]}}</li>
+   * <li>{@code {"type":"add_image","url":"https://.../pic.png"}} or {@code {"type":"add_image","document_id":"<uuid>"}}</li>
+   * <li>{@code {"type":"replace_text","search":"{{name}}","replace":"ACME"}}</li>
+   * <li>{@code {"type":"set_html","html":"<h1>..</h1>"}} (CREATE only, must be the
+   * only operation; authored via the HTML conversion path, not the Builder)</li>
+   * </ul>
+   * <p>
+   * When the user attaches an image in the EVA chat, the agent injects the
+   * chat-attachment reference into the top-level {@code attachmentObjectType} /
+   * {@code attachmentObjectId} parameters; any {@code add_image} operation that
+   * has neither {@code url} nor {@code document_id} then resolves its bytes from
+   * that attachment (see {@link #resolveImageBytes}).
+   *
+   * @param documentId optional JCR uuid of an existing document to modify
+   * @param parentFolderId folder id where a new document is created (create mode)
+   * @param name new document name WITHOUT extension (create mode)
+   * @param operations a JSON array string of document operations
+   * @param attachmentObjectType object type of the EVA chat-attachment image source (auto-filled by the agent)
+   * @param attachmentObjectId object id of the EVA chat-attachment image source (auto-filled by the agent)
+   * @return the created / modified document (id + name)
+   */
+  public OfficeDocumentModel editDocument(String documentId,
+                                          String parentFolderId,
+                                          String name,
+                                          String operations,
+                                          String attachmentObjectType,
+                                          String attachmentObjectId) throws IllegalAccessException, ObjectNotFoundException {
+    // set_html is authored through the HTML->docx conversion API, not the
+    // Builder. It is only supported as the sole operation of a CREATE call.
+    JSONArray ops = parseOperations(operations);
+    if (containsHtmlOp(ops)) {
+      return createDocumentFromHtml(documentId, parentFolderId, name, ops);
+    }
+    return runEdit("docx", documentId, parentFolderId, name, operations, attachmentObjectType, attachmentObjectId);
+  }
+
+  /**
+   * Shared CREATE-or-MODIFY orchestration for the three structured office tools:
+   * builds the format-specific Document Builder script (CreateFile or OpenFile,
+   * apply operations, SaveFile), gathers the referenced assets, runs the shared
+   * {@code runDocBuilderScript} primitive, then stores a new file (create) or a
+   * new version of the source file (modify).
+   */
+  private OfficeDocumentModel runEdit(String format,
+                                      String documentId,
+                                      String parentFolderId,
+                                      String name,
+                                      String operations,
+                                      String attachmentObjectType,
+                                      String attachmentObjectId) throws IllegalAccessException, ObjectNotFoundException {
+    boolean modify = StringUtils.isNotBlank(documentId);
+    if (!modify) {
+      if (StringUtils.isBlank(parentFolderId)) {
+        throw new IllegalArgumentException("Provide either 'document_id' to modify an existing file, or 'parent_folder_id' (and "
+            + "'name') to create a new one. Call get_root_folder_for_user / get_root_folder_by_space / "
+            + "get_documents_by_folder_id to obtain a folder id.");
+      }
+      if (StringUtils.isBlank(name)) {
+        throw new IllegalArgumentException("The 'name' parameter is mandatory when creating a new document.");
+      }
+    }
+    JSONArray ops = parseOperations(operations);
+
+    UserSession userSession = openUserSession();
+    try {
+      Map<String, byte[]> assets = new LinkedHashMap<>();
+      StringBuilder script = new StringBuilder();
+      Node target = null;
+      if (modify) {
+        target = resolveNode(userSession.session(), documentId);
+        assets.put("input", readNodeBytes(target, documentId));
+        script.append("builder.OpenFile(\"@@ASSET:input@@\", \"\");\n");
+      } else {
+        script.append("builder.CreateFile(\"").append(format).append("\");\n");
+      }
+
+      switch (format) {
+        case "xlsx":
+          appendSpreadsheetOps(ops, script);
+          break;
+        case "pptx":
+          appendPresentationOps(ops, script, assets, userSession.session(), !modify, attachmentObjectType, attachmentObjectId);
+          break;
+        default:
+          appendDocumentOps(ops, script, assets, userSession.session(), attachmentObjectType, attachmentObjectId);
+          break;
+      }
+
+      String outputName = "result." + format;
+      script.append("builder.SaveFile(\"").append(format).append("\", \"").append(outputName).append("\");\n");
+      script.append("builder.CloseFile();\n");
+
+      byte[] out = onlyofficeEditorService.runDocBuilderScript(script.toString(),
+                                                               assets,
+                                                               format,
+                                                               outputName,
+                                                               getCurrentUserName());
+      if (out == null || out.length == 0) {
+        throw new IllegalStateException(CONVERT_FAILED_MSG);
+      }
+      if (modify) {
+        try {
+          onlyofficeEditorService.saveNewVersion(target, out, getCurrentUserName());
+        } catch (RepositoryException e) {
+          throw new IllegalStateException("Could not save the modified document %s as a new version: %s".formatted(documentId,
+                                                                                                                   e.getMessage()));
+        }
+        return toModelFromNode(target, documentId);
+      }
+      return importContent(parentFolderId, appendExtension(name, format), out);
+    } finally {
+      userSession.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // generate_document (template + search/replace merge)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generates a new document from a template by replacing every placeholder with
+   * its value (a search/replace merge run through the Document Builder). Unlike
+   * {@code edit_document}'s {@code replace_text} (which edits a document in place
+   * for one-off substitutions), this is the template-fill workflow: it always
+   * CREATES a new file from a template document and takes the whole placeholder
+   * map at once.
+   *
+   * @param templateDocumentId the JCR uuid of the template document (e.g. a docx
+   *          with {@code {{client}}} placeholders)
+   * @param folderId optional destination folder; defaults to the template's folder
+   * @param name the produced document name WITHOUT extension; defaults to the
+   *          template name
+   * @param data a JSON object string mapping each placeholder to its replacement,
+   *          e.g. {@code {"{{client}}":"ACME","{{amount}}":"42,000 EUR"}}
+   * @return the generated document (id + name)
+   */
+  public OfficeDocumentModel generateDocument(String templateDocumentId,
+                                              String folderId,
+                                              String name,
+                                              String data) throws IllegalAccessException, ObjectNotFoundException {
+    if (StringUtils.isBlank(templateDocumentId)) {
+      throw new IllegalArgumentException("The 'template_document_id' parameter is mandatory (the JCR uuid of the template).");
+    }
+    JSONObject dataObject = parseObject(data, "data");
+    if (dataObject.length() == 0) {
+      throw new IllegalArgumentException("The 'data' parameter must be a non-empty JSON object mapping each placeholder to "
+          + "its replacement value, e.g. {\"{{client}}\":\"ACME\"}.");
+    }
+    UserSession userSession = openUserSession();
+    try {
+      Node template = resolveNode(userSession.session(), templateDocumentId);
+      Map<String, byte[]> assets = new LinkedHashMap<>();
+      assets.put("input", readNodeBytes(template, templateDocumentId));
+
+      StringBuilder script = new StringBuilder();
+      script.append("builder.OpenFile(\"@@ASSET:input@@\", \"\");\n");
+      script.append("var oDocument = Api.GetDocument();\n");
+      for (String search : dataObject.keySet()) {
+        String replace = String.valueOf(dataObject.get(search));
+        script.append("oDocument.SearchAndReplace({\"searchString\":")
+              .append(jsString(search))
+              .append(", \"replaceString\":")
+              .append(jsString(replace))
+              .append("});\n");
+      }
+      script.append("builder.SaveFile(\"docx\", \"result.docx\");\n");
+      script.append("builder.CloseFile();\n");
+
+      byte[] out = onlyofficeEditorService.runDocBuilderScript(script.toString(),
+                                                               assets,
+                                                               "docx",
+                                                               "result.docx",
+                                                               getCurrentUserName());
+      if (out == null || out.length == 0) {
+        throw new IllegalStateException(CONVERT_FAILED_MSG);
+      }
+      String baseName = StringUtils.isNotBlank(name) ? name : stripExtension(nodeTitleOrName(template));
+      String targetFolder = StringUtils.isNotBlank(folderId) ? folderId : parentFolderIdOf(template, templateDocumentId);
+      return importContent(targetFolder, appendExtension(baseName, "docx"), out);
+    } finally {
+      userSession.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // convert_document (format -> format)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Converts an existing office document to another format using the ONLYOFFICE
+   * Document Server, storing the result as {@code <originalName>.<target_format>}.
+   *
+   * @param documentId the JCR uuid of the source document
+   * @param targetFormat the produced format, e.g. docx, xlsx, pptx, odt, pdf, csv
+   * @param folderId optional destination folder; defaults to the source folder
+   * @return the created document (id + name)
+   */
+  public OfficeDocumentModel convertDocument(String documentId,
+                                             String targetFormat,
+                                             String folderId) throws IllegalAccessException, ObjectNotFoundException {
+    if (StringUtils.isBlank(documentId)) {
+      throw new IllegalArgumentException("The 'document_id' parameter is mandatory (the JCR uuid of the document to convert).");
+    }
+    if (StringUtils.isBlank(targetFormat)) {
+      throw new IllegalArgumentException("The 'target_format' parameter is mandatory, e.g. docx, xlsx, pptx, odt, pdf, csv.");
+    }
+    String target = normalizeExtension(targetFormat);
+    UserSession userSession = openUserSession();
+    try {
+      Node node = resolveNode(userSession.session(), documentId);
+      String baseName = stripExtension(nodeTitleOrName(node));
+      String originalType = extensionOf(nodeTitleOrName(node));
+      String targetFolderId = StringUtils.isNotBlank(folderId) ? folderId : parentFolderIdOf(node, documentId);
+      byte[] converted = onlyofficeEditorService.convertNodeContent(node, target, originalType, getCurrentUserName());
+      if (converted == null || converted.length == 0) {
+        throw new IllegalStateException(CONVERT_FAILED_MSG);
+      }
+      return importContent(targetFolderId, baseName + "." + target, converted);
+    } finally {
+      userSession.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // export_document_as_pdf
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Exports an existing office document as a PDF, stored as {@code <name>.pdf}.
+   *
+   * @param documentId the JCR uuid of the source document
+   * @param parentFolderId optional destination folder; defaults to the source folder
+   * @return the created PDF document (id + name)
+   */
+  public OfficeDocumentModel exportDocumentAsPdf(String documentId,
+                                                 String parentFolderId) throws IllegalAccessException,
+                                                                        ObjectNotFoundException {
+    if (StringUtils.isBlank(documentId)) {
+      throw new IllegalArgumentException("The 'document_id' parameter is mandatory (the JCR uuid of the document to export).");
+    }
+    UserSession userSession = openUserSession();
+    try {
+      Node node = resolveNode(userSession.session(), documentId);
+      String baseName = stripExtension(nodeTitleOrName(node));
+      String targetFolderId = StringUtils.isNotBlank(parentFolderId) ? parentFolderId : parentFolderIdOf(node, documentId);
+      byte[] pdf;
+      try {
+        pdf = onlyofficeEditorService.convertNodeContentToPdf(node, getCurrentUserName());
+      } catch (RepositoryException e) {
+        throw new IllegalStateException("Could not export the document %s as PDF: %s".formatted(documentId, e.getMessage()));
+      }
+      if (pdf == null || pdf.length == 0) {
+        throw new IllegalStateException(CONVERT_FAILED_MSG);
+      }
+      return importContent(targetFolderId, baseName + ".pdf", pdf);
+    } finally {
+      userSession.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // get_document_editor_link
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the ONLYOFFICE online editor URL of a document, so it can be opened
+   * for editing. The user must have edit permission on the document.
+   *
+   * @param documentId the JCR uuid of the document
+   * @return the document id, name and editor URL
+   */
+  public OfficeEditorLinkModel getDocumentEditorLink(String documentId) throws IllegalAccessException,
+                                                                        ObjectNotFoundException {
+    if (StringUtils.isBlank(documentId)) {
+      throw new IllegalArgumentException("The 'document_id' parameter is mandatory (the JCR uuid of the document).");
+    }
+    UserSession userSession = openUserSession();
+    try {
+      Node node = resolveNode(userSession.session(), documentId);
+      String baseUrl = System.getProperty("exo.base.url");
+      if (StringUtils.isBlank(baseUrl)) {
+        throw new IllegalStateException("The platform base URL (exo.base.url) is not configured, so no editor link can be built.");
+      }
+      URI uri = URI.create(baseUrl);
+      String link;
+      try {
+        link = onlyofficeEditorService.getEditorLink(node, uri.getScheme(), uri.getHost(), uri.getPort());
+      } catch (EditorLinkNotFoundException e) {
+        throw new IllegalAccessException(("The document %s cannot be opened in the online editor: it is not an editable office "
+            + "document, or you do not have edit permission on it.").formatted(documentId));
+      } catch (RepositoryException e) {
+        throw new IllegalStateException("Could not build the editor link for document %s: %s".formatted(documentId, e.getMessage()));
+      }
+      return new OfficeEditorLinkModel(documentId, nodeTitleOrName(node), link);
+    } finally {
+      userSession.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Document Builder script generators (lean, per format)
+  // ---------------------------------------------------------------------------
+
+  private void appendSpreadsheetOps(JSONArray ops, StringBuilder s) {
+    s.append("var oWorksheet = Api.GetActiveSheet();\n");
+    boolean sheetAdded = false;
+    for (int i = 0; i < ops.length(); i++) {
+      JSONObject op = ops.getJSONObject(i);
+      String type = opType(op);
+      switch (type) {
+        case "set_cells": {
+          String start = op.optString("start", "A1");
+          int[] rc = cellToRowCol(start);
+          JSONArray rows = op.optJSONArray("values");
+          if (rows == null) {
+            throw new IllegalArgumentException("set_cells requires a 'values' 2D array, e.g. [[\"A\",\"B\"],[1,2]].");
+          }
+          for (int r = 0; r < rows.length(); r++) {
+            JSONArray cols = rows.optJSONArray(r);
+            if (cols == null) {
+              continue;
+            }
+            for (int c = 0; c < cols.length(); c++) {
+              Object value = cols.get(c);
+              s.append("oWorksheet.GetRangeByNumber(")
+               .append(rc[0] + r)
+               .append(", ")
+               .append(rc[1] + c)
+               .append(").SetValue(")
+               .append(jsValue(value))
+               .append(");\n");
+            }
+          }
+          break;
+        }
+        case "set_formula": {
+          String cell = requireString(op, "cell", "set_formula");
+          String formula = requireString(op, "formula", "set_formula");
+          s.append("oWorksheet.GetRange(").append(jsString(cell)).append(").SetValue(").append(jsString(formula)).append(");\n");
+          break;
+        }
+        case "add_chart": {
+          String chartType = normalizeChartType(op.optString("chart", op.optString("type_chart", "bar")));
+          String range = requireString(op, "range", "add_chart");
+          String title = op.optString("title", "");
+          s.append("var oChart = oWorksheet.AddChart(")
+           .append(jsString(range))
+           .append(", true, ")
+           .append(jsString(chartType))
+           .append(", 2, ")
+           .append(100 * EMU)
+           .append(", ")
+           .append(70 * EMU)
+           .append(", 3, 0, 8, 0);\n");
+          if (StringUtils.isNotBlank(title)) {
+            s.append("oChart.SetTitle(").append(jsString(title)).append(", 14);\n");
+          }
+          break;
+        }
+        case "add_sheet": {
+          String sheetName = requireString(op, "name", "add_sheet");
+          s.append("Api.AddSheet(").append(jsString(sheetName)).append(");\n");
+          s.append("oWorksheet = Api.GetActiveSheet();\n");
+          sheetAdded = true;
+          break;
+        }
+        default:
+          throw unsupportedOp(type, "edit_spreadsheet");
+      }
+    }
+    // ONLYOFFICE xlsx->PDF conversion (convert_document / export_document_as_pdf via the
+    // Document Server /converter) exports ONLY the ACTIVE sheet. Api.AddSheet leaves the
+    // newly-added (usually empty) sheet active, so exporting such a spreadsheet produced a
+    // blank ~2KB PDF. Re-activating the first (data) sheet before SaveFile makes the primary
+    // sheet the one exported. Verified against the live Document Server: with the empty added
+    // sheet left active the PDF was 1936 bytes (blank); re-activating Sheet1 yielded a 26KB PDF
+    // with the full table + chart. (SetPrintArea is NOT available on the builder Api here — it
+    // fails with docbuilder error -3 — so activating the data sheet is the working fix.)
+    if (sheetAdded) {
+      s.append("Api.GetSheets()[0].SetActive();\n");
+      s.append("oWorksheet = Api.GetActiveSheet();\n");
+    }
+  }
+
+  private void appendPresentationOps(JSONArray ops,
+                                     StringBuilder s,
+                                     Map<String, byte[]> assets,
+                                     Session session,
+                                     boolean create,
+                                     String attachmentObjectType,
+                                     String attachmentObjectId)
+                                                                                                                  throws IllegalAccessException,
+                                                                                                                  ObjectNotFoundException {
+    s.append("var oPresentation = Api.GetPresentation();\n");
+    s.append("var __fill = Api.CreateSolidFill(Api.CreateRGBColor(255, 255, 255));\n");
+    s.append("var __stroke = Api.CreateStroke(0, Api.CreateNoFill());\n");
+    // Explicit BLACK text fill. Api.CreateShape gives the shape a default style whose
+    // fontRef is the "lt1" (light-1 = white) theme colour, meant for a colour-filled
+    // shape. Because we override the shape fill to white, a run WITHOUT an explicit
+    // colour renders as white-on-white and is invisible (the slides looked empty even
+    // though the text was present in the XML). Every run below sets this fill so the
+    // title + bullets are actually visible. Verified against the live Document Server:
+    // without SetFill the pptx->PDF page was blank; with it the text renders in black.
+    s.append("var __textFill = Api.CreateSolidFill(Api.CreateRGBColor(0, 0, 0));\n");
+    // Helper: (re)build a slide's text with a title + bullet lines.
+    s.append("function __setSlideText(oSlide, title, bullets) {\n")
+     .append("  oSlide.RemoveAllObjects();\n")
+     .append("  if (title) {\n")
+     .append("    var t = Api.CreateShape(\"rect\", 300*").append(EMU).append(", 50*").append(EMU).append(", __fill, __stroke);\n")
+     .append("    t.SetPosition(20*").append(EMU).append(", 20*").append(EMU).append(");\n")
+     .append("    var tp = t.GetContent().GetElement(0);\n")
+     .append("    var tr = Api.CreateRun(); tr.AddText(title); tr.SetBold(true); tr.SetFontSize(32); tr.SetFill(__textFill); tp.AddElement(tr);\n")
+     .append("    oSlide.AddObject(t);\n")
+     .append("  }\n")
+     .append("  if (bullets && bullets.length) {\n")
+     .append("    var b = Api.CreateShape(\"rect\", 500*").append(EMU).append(", 300*").append(EMU).append(", __fill, __stroke);\n")
+     .append("    b.SetPosition(20*").append(EMU).append(", 90*").append(EMU).append(");\n")
+     .append("    var doc = b.GetContent();\n")
+     .append("    for (var i = 0; i < bullets.length; i++) {\n")
+     .append("      var p = (i === 0) ? doc.GetElement(0) : Api.CreateParagraph();\n")
+     .append("      if (i !== 0) doc.Push(p);\n")
+     .append("      var r = Api.CreateRun(); r.AddText(\"\\u2022 \" + bullets[i]); r.SetFontSize(18); r.SetFill(__textFill); p.AddElement(r);\n")
+     .append("    }\n")
+     .append("    oSlide.AddObject(b);\n")
+     .append("  }\n")
+     .append("}\n");
+
+    int imageIndex = 0;
+    // On CREATE, builder.CreateFile("pptx") starts the presentation with one blank
+    // default slide (index 0). The first add_slide must POPULATE that default slide
+    // instead of appending a new one, otherwise every created presentation opens on a
+    // leading blank slide. Consumed by the first add_slide (or cancelled by a set_slide,
+    // which already targets an existing slide, so a later add_slide appends normally).
+    boolean reuseDefaultSlide = create;
+    for (int i = 0; i < ops.length(); i++) {
+      JSONObject op = ops.getJSONObject(i);
+      String type = opType(op);
+      switch (type) {
+        case "add_slide": {
+          if (reuseDefaultSlide) {
+            s.append("var oSlide = oPresentation.GetSlideByIndex(0);\n");
+            reuseDefaultSlide = false;
+          } else {
+            s.append("var oSlide = Api.CreateSlide(); oPresentation.AddSlide(oSlide);\n");
+          }
+          s.append("__setSlideText(oSlide, ")
+           .append(jsString(op.optString("title", "")))
+           .append(", ")
+           .append(jsStringArray(op.optJSONArray("bullets")))
+           .append(");\n");
+          break;
+        }
+        case "set_slide": {
+          reuseDefaultSlide = false;
+          int index = op.optInt("index", 0);
+          s.append("var oSlide = oPresentation.GetSlideByIndex(").append(index).append(");\n");
+          s.append("if (oSlide) __setSlideText(oSlide, ")
+           .append(jsString(op.optString("title", "")))
+           .append(", ")
+           .append(jsStringArray(op.optJSONArray("bullets")))
+           .append(");\n");
+          break;
+        }
+        case "add_image": {
+          int index = op.optInt("slide", op.optInt("index", 0));
+          String assetName = "img" + (imageIndex++);
+          assets.put(assetName + ".png", resolveImageBytes(op, session, attachmentObjectType, attachmentObjectId));
+          s.append("var oImgSlide = oPresentation.GetSlideByIndex(").append(index).append(");\n");
+          s.append("if (oImgSlide) { var oImage = Api.CreateImage(\"@@ASSET:")
+           .append(assetName)
+           .append(".png@@\", 120*").append(EMU).append(", 90*").append(EMU).append("); oImage.SetPosition(30*")
+           .append(EMU).append(", 100*").append(EMU).append("); oImgSlide.AddObject(oImage); }\n");
+          break;
+        }
+        default:
+          throw unsupportedOp(type, "edit_presentation");
+      }
+    }
+  }
+
+  private void appendDocumentOps(JSONArray ops,
+                                 StringBuilder s,
+                                 Map<String, byte[]> assets,
+                                 Session session,
+                                 String attachmentObjectType,
+                                 String attachmentObjectId) throws IllegalAccessException, ObjectNotFoundException {
+    s.append("var oDocument = Api.GetDocument();\n");
+    int imageIndex = 0;
+    for (int i = 0; i < ops.length(); i++) {
+      JSONObject op = ops.getJSONObject(i);
+      String type = opType(op);
+      switch (type) {
+        case "add_heading": {
+          int level = clamp(op.optInt("level", 1), 1, 6);
+          String text = requireString(op, "text", "add_heading");
+          int size = 32 - (level - 1) * 4;
+          s.append("var oP = Api.CreateParagraph(); var oR = Api.CreateRun(); oR.AddText(")
+           .append(jsString(text))
+           .append("); oR.SetBold(true); oR.SetFontSize(")
+           .append(Math.max(size, 16))
+           .append("); oP.AddElement(oR); oDocument.Push(oP);\n");
+          break;
+        }
+        case "add_paragraph": {
+          String text = requireString(op, "text", "add_paragraph");
+          boolean bold = op.optBoolean("bold", false);
+          boolean italic = op.optBoolean("italic", false);
+          s.append("var oP = Api.CreateParagraph(); var oR = Api.CreateRun(); oR.AddText(").append(jsString(text)).append(");");
+          if (bold) {
+            s.append(" oR.SetBold(true);");
+          }
+          if (italic) {
+            s.append(" oR.SetItalic(true);");
+          }
+          s.append(" oP.AddElement(oR); oDocument.Push(oP);\n");
+          break;
+        }
+        case "add_table": {
+          JSONArray rows = op.optJSONArray("rows");
+          if (rows == null || rows.length() == 0) {
+            throw new IllegalArgumentException("add_table requires a non-empty 'rows' 2D array.");
+          }
+          int rowCount = rows.length();
+          int colCount = 0;
+          for (int r = 0; r < rowCount; r++) {
+            JSONArray cols = rows.optJSONArray(r);
+            if (cols != null) {
+              colCount = Math.max(colCount, cols.length());
+            }
+          }
+          if (colCount == 0) {
+            throw new IllegalArgumentException("add_table rows must contain at least one column.");
+          }
+          // ONLYOFFICE Document Builder's Api.CreateTable is (nRows, nCols) — rows first.
+          // Emitting (colCount, rowCount) built a table with too few rows, so GetRow(r) for
+          // the later rows threw "Row index out of bounds" (docbuilder ExitCode error:-80).
+          // Verified against the live Document Server: CreateTable(rowCount, colCount) is correct.
+          s.append("var oTable = Api.CreateTable(").append(rowCount).append(", ").append(colCount).append(");\n");
+          s.append("oTable.SetWidth(\"percent\", 100);\n");
+          for (int r = 0; r < rowCount; r++) {
+            JSONArray cols = rows.optJSONArray(r);
+            if (cols == null) {
+              continue;
+            }
+            for (int c = 0; c < cols.length() && c < colCount; c++) {
+              s.append("oTable.GetRow(").append(r).append(").GetCell(").append(c)
+               .append(").GetContent().GetElement(0).AddText(").append(jsString(String.valueOf(cols.get(c)))).append(");\n");
+            }
+          }
+          s.append("oDocument.Push(oTable);\n");
+          break;
+        }
+        case "add_image": {
+          String assetName = "img" + (imageIndex++);
+          assets.put(assetName + ".png", resolveImageBytes(op, session, attachmentObjectType, attachmentObjectId));
+          s.append("var oImg = Api.CreateImage(\"@@ASSET:")
+           .append(assetName)
+           .append(".png@@\", 120*").append(EMU).append(", 90*").append(EMU).append(");\n");
+          s.append("var oImgP = Api.CreateParagraph(); oImgP.AddDrawing(oImg); oDocument.Push(oImgP);\n");
+          break;
+        }
+        case "replace_text": {
+          String search = requireString(op, "search", "replace_text");
+          String replace = op.optString("replace", "");
+          s.append("oDocument.SearchAndReplace({\"searchString\":")
+           .append(jsString(search))
+           .append(", \"replaceString\":")
+           .append(jsString(replace))
+           .append("});\n");
+          break;
+        }
+        default:
+          throw unsupportedOp(type, "edit_document");
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // HTML -> docx (set_html), preserved from the former create_office_document
+  // ---------------------------------------------------------------------------
+
+  private OfficeDocumentModel createDocumentFromHtml(String documentId,
+                                                     String parentFolderId,
+                                                     String name,
+                                                     JSONArray ops) throws IllegalAccessException, ObjectNotFoundException {
+    if (StringUtils.isNotBlank(documentId)) {
+      throw new IllegalArgumentException("The 'set_html' operation authors a brand-new document from HTML and cannot modify an "
+          + "existing one. Omit 'document_id', or use structured operations (add_heading / add_paragraph / ...) to edit a document.");
+    }
+    if (ops.length() != 1) {
+      throw new IllegalArgumentException("The 'set_html' operation cannot be combined with other operations in one call. "
+          + "Send it alone to author a document from HTML, or use only structured operations.");
+    }
+    if (StringUtils.isBlank(parentFolderId)) {
+      throw new IllegalArgumentException("The 'parent_folder_id' parameter is mandatory to create a document from HTML.");
+    }
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("The 'name' parameter is mandatory to create a document from HTML.");
+    }
+    String html = ops.getJSONObject(0).optString("html", "");
+    if (StringUtils.isBlank(html)) {
+      throw new IllegalArgumentException("The 'set_html' operation requires a non-empty 'html' value.");
+    }
+    UserSession userSession = openUserSession();
+    Node tmpNode = null;
+    try {
+      Node parent = resolveNode(userSession.session(), parentFolderId);
+      byte[] converted;
+      try {
+        tmpNode = createTempHtmlNode(parent, html, userSession.session());
+        converted = onlyofficeEditorService.convertNodeContent(tmpNode, "docx", "html", getCurrentUserName());
+      } catch (RepositoryException e) {
+        throw new IllegalStateException("Could not stage the HTML content for conversion: " + e.getMessage());
+      }
+      if (converted == null || converted.length == 0) {
+        throw new IllegalStateException(CONVERT_FAILED_MSG);
+      }
+      return importContent(parentFolderId, appendExtension(name, "docx"), converted);
+    } finally {
+      deleteQuietly(tmpNode);
+      userSession.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Operations parsing / JS emission helpers
+  // ---------------------------------------------------------------------------
+
+  private JSONArray parseOperations(String operations) {
+    if (StringUtils.isBlank(operations)) {
+      throw new IllegalArgumentException("The 'operations' parameter is mandatory: a JSON array string of operations, e.g. "
+          + "[{\"type\":\"add_paragraph\",\"text\":\"Hello\"}].");
+    }
+    String trimmed = operations.trim();
+    try {
+      if (trimmed.startsWith("[")) {
+        return new JSONArray(trimmed);
+      }
+      if (trimmed.startsWith("{")) {
+        JSONObject obj = new JSONObject(trimmed);
+        if (obj.has("operations")) {
+          return obj.getJSONArray("operations");
+        }
+        JSONArray single = new JSONArray();
+        single.put(obj);
+        return single;
+      }
+    } catch (JSONException e) {
+      throw new IllegalArgumentException("The 'operations' parameter is not valid JSON: " + e.getMessage());
+    }
+    throw new IllegalArgumentException("The 'operations' parameter must be a JSON array (or object) string.");
+  }
+
+  private JSONObject parseObject(String value, String paramName) {
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException("The '%s' parameter is mandatory: a JSON object string.".formatted(paramName));
+    }
+    try {
+      return new JSONObject(value.trim());
+    } catch (JSONException e) {
+      throw new IllegalArgumentException("The '%s' parameter is not a valid JSON object: %s".formatted(paramName, e.getMessage()));
+    }
+  }
+
+  private boolean containsHtmlOp(JSONArray ops) {
+    for (int i = 0; i < ops.length(); i++) {
+      String type = ops.getJSONObject(i).optString("type", "");
+      if ("set_html".equals(type) || "append_html".equals(type)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String opType(JSONObject op) {
+    String type = op.optString("type", "");
+    if (StringUtils.isBlank(type)) {
+      throw new IllegalArgumentException("Every operation must have a 'type'. Got: " + op);
+    }
+    return type;
+  }
+
+  private static IllegalArgumentException unsupportedOp(String type, String tool) {
+    return new IllegalArgumentException("Unsupported operation '%s' for %s.".formatted(type, tool));
+  }
+
+  private static String requireString(JSONObject op, String field, String opName) {
+    String value = op.optString(field, "");
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException("The '%s' operation requires a '%s' value.".formatted(opName, field));
+    }
+    return value;
+  }
+
+  /** Emits a JS string literal, escaping the value safely. */
+  private static String jsString(String value) {
+    String v = value == null ? "" : value;
+    StringBuilder sb = new StringBuilder(v.length() + 2);
+    sb.append('"');
+    for (int i = 0; i < v.length(); i++) {
+      char c = v.charAt(i);
+      switch (c) {
+        case '\\':
+          sb.append("\\\\");
+          break;
+        case '"':
+          sb.append("\\\"");
+          break;
+        case '\n':
+          sb.append("\\n");
+          break;
+        case '\r':
+          sb.append("\\r");
+          break;
+        case '\t':
+          sb.append("\\t");
+          break;
+        case '<':
+          sb.append("\\u003c");
+          break;
+        case '>':
+          sb.append("\\u003e");
+          break;
+        default:
+          if (c < 0x20) {
+            sb.append(String.format("\\u%04x", (int) c));
+          } else {
+            sb.append(c);
+          }
+      }
+    }
+    sb.append('"');
+    return sb.toString();
+  }
+
+  /** Emits a numeric literal for numbers, otherwise a JS string literal. */
+  private static String jsValue(Object value) {
+    if (value instanceof Number) {
+      return value.toString();
+    }
+    if (value instanceof Boolean) {
+      return value.toString();
+    }
+    return jsString(String.valueOf(value));
+  }
+
+  private static String jsStringArray(JSONArray array) {
+    if (array == null || array.length() == 0) {
+      return "[]";
+    }
+    StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < array.length(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append(jsString(String.valueOf(array.get(i))));
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+
+  private static String normalizeChartType(String chart) {
+    String c = StringUtils.lowerCase(StringUtils.trimToEmpty(chart));
+    switch (c) {
+      case "line":
+        return "line";
+      case "pie":
+        return "pie";
+      case "column":
+      case "bar":
+      case "":
+        return "bar";
+      default:
+        return c;
+    }
+  }
+
+  /** Parses an A1 cell reference into a 0-based {row, col}. */
+  private static int[] cellToRowCol(String cell) {
+    String c = StringUtils.trimToEmpty(cell).toUpperCase(java.util.Locale.ROOT);
+    int i = 0;
+    int col = 0;
+    while (i < c.length() && Character.isLetter(c.charAt(i))) {
+      col = col * 26 + (c.charAt(i) - 'A' + 1);
+      i++;
+    }
+    int row = 0;
+    if (i < c.length()) {
+      try {
+        row = Integer.parseInt(c.substring(i));
+      } catch (NumberFormatException e) {
+        row = 1;
+      }
+    }
+    return new int[] { Math.max(row - 1, 0), Math.max(col - 1, 0) };
+  }
+
+  private static int clamp(int value, int min, int max) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Image resolution (url via SSRF-guarded fetch, or a DMS document_id)
+  // ---------------------------------------------------------------------------
+
+  // Resolves the bytes of an image referenced by an add_image operation, in a
+  // clear precedence order: (1) the op's explicit http(s) 'url', (2) the op's
+  // explicit DMS 'document_id', (3) a per-op attachment reference, then (4) the
+  // tool-level chat-attachment reference EVA injects (attachmentObjectType +
+  // attachmentObjectId) when the user attaches an image in the chat. Sources 3
+  // and 4 are read as the current user through the shared UploadToolUtils
+  // resolver, so platform ACLs are enforced (an unreadable object throws).
+  private byte[] resolveImageBytes(JSONObject op,
+                                   Session session,
+                                   String attachmentObjectType,
+                                   String attachmentObjectId) throws IllegalAccessException, ObjectNotFoundException {
+    String url = op.optString("url", "");
+    String imageDocumentId = op.optString("document_id", op.optString("image_document_id", ""));
+    // A per-op attachment reference overrides the tool-level one; either is the chat
+    // attachment EVA injected. Resolve it up-front as a FALLBACK: EVA sometimes emits a
+    // placeholder/invented url (e.g. https://example.com/...) alongside the real attached
+    // image, and a bare url/document_id would otherwise shadow it and fail the whole edit.
+    String objectType = StringUtils.defaultIfBlank(op.optString("attachment_object_type", ""), attachmentObjectType);
+    String objectId = StringUtils.defaultIfBlank(op.optString("attachment_object_id", ""), attachmentObjectId);
+    boolean hasAttachment = StringUtils.isNotBlank(objectId);
+    if (StringUtils.isNotBlank(url)) {
+      try {
+        return UploadToolUtils.fetchUrl(url, MAX_IMAGE_BYTES, "image.png").bytes();
+      } catch (RuntimeException e) {
+        if (!hasAttachment) {
+          throw e;
+        }
+        LOG.info("add_image url '{}' did not resolve ({}); using the attached image instead", url, e.getMessage());
+      }
+    } else if (StringUtils.isNotBlank(imageDocumentId)) {
+      try {
+        Node imageNode = resolveNode(session, imageDocumentId);
+        return readNodeBytes(imageNode, imageDocumentId);
+      } catch (IllegalAccessException | ObjectNotFoundException | RuntimeException e) {
+        if (!hasAttachment) {
+          throw e;
+        }
+        LOG.info("add_image document_id '{}' did not resolve ({}); using the attached image instead",
+                 imageDocumentId,
+                 e.getMessage());
+      }
+    }
+    if (hasAttachment) {
+      Identity aclIdentity = userAcl.getUserIdentity(getCurrentUserName());
+      UploadToolUtils.FetchedContent fetched = UploadToolUtils.resolveImage(attachmentService,
+                                                                            fileService,
+                                                                            aclIdentity,
+                                                                            new UploadToolUtils.ImageSource(null,
+                                                                                                            null,
+                                                                                                            objectType,
+                                                                                                            objectId),
+                                                                            MAX_IMAGE_BYTES);
+      return fetched.bytes();
+    }
+    throw new IllegalArgumentException("An 'add_image' operation requires either a 'url' (http/https image), a "
+        + "'document_id' (a DMS image file), or an attached image (attachment_object_type + attachment_object_id).");
+  }
+
+  private byte[] readNodeBytes(Node node, String documentId) throws IllegalAccessException {
+    try {
+      Node content = node.getNode("jcr:content");
+      try (InputStream in = content.getProperty("jcr:data").getStream()) {
+        return in.readAllBytes();
+      }
+    } catch (AccessDeniedException e) {
+      throw new IllegalAccessException("You are not allowed to read the content of document %s.".formatted(documentId));
+    } catch (RepositoryException | IOException e) {
+      throw new IllegalStateException("Could not read the content of document %s: %s".formatted(documentId, e.getMessage()));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // User session / node resolution (acts as the user, ACL enforced)
+  // ---------------------------------------------------------------------------
+
+  protected UserSession openUserSession() {
+    Identity aclIdentity = userAcl.getUserIdentity(getCurrentUserName());
+    if (aclIdentity == null) {
+      throw new IllegalStateException("Cannot resolve the current user identity, so no document can be accessed.");
+    }
+    SessionProvider provider = OfficeDocumentsThumbnailPlugin.getUserSessionProvider(repositoryService, aclIdentity);
+    try {
+      ManageableRepository repository = repositoryService.getCurrentRepository();
+      String workspace = repository.getConfiguration().getDefaultWorkspaceName();
+      Session session = provider.getSession(workspace, repository);
+      return new UserSession(provider, session);
+    } catch (RepositoryException e) {
+      provider.close();
+      throw new IllegalStateException("Could not open a JCR session for the current user: " + e.getMessage());
+    }
+  }
+
+  private Node resolveNode(Session session, String documentId) throws IllegalAccessException, ObjectNotFoundException {
+    try {
+      return session.getNodeByUUID(documentId);
+    } catch (ItemNotFoundException e) {
+      throw new ObjectNotFoundException("No document found with id %s. Verify the id (it must be a JCR uuid)."
+          .formatted(documentId));
+    } catch (AccessDeniedException e) {
+      throw new IllegalAccessException("You are not allowed to access the document %s.".formatted(documentId));
+    } catch (RepositoryException e) {
+      throw new IllegalStateException("Could not resolve the document %s: %s".formatted(documentId, e.getMessage()));
+    }
+  }
+
+  private Node createTempHtmlNode(Node parent, String content, Session session) throws RepositoryException {
+    String tmpName = "eva-onlyoffice-tmp-" + UUID.randomUUID() + ".html";
+    Node file = parent.addNode(tmpName, "nt:file");
+    if (!file.isNodeType("mix:referenceable")) {
+      file.addMixin("mix:referenceable");
+    }
+    Node resource = file.addNode("jcr:content", "nt:resource");
+    resource.setProperty("jcr:mimeType", "text/html");
+    resource.setProperty("jcr:data",
+                         session.getValueFactory().createValue(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))));
+    resource.setProperty("jcr:lastModified", Calendar.getInstance());
+    session.save();
+    return file;
+  }
+
+  private void deleteQuietly(Node node) {
+    if (node == null) {
+      return;
+    }
+    try {
+      Session session = node.getSession();
+      node.remove();
+      session.save();
+    } catch (Exception e) {
+      LOG.warn("Could not delete the temporary conversion node", e);
+    }
+  }
+
+  private String nodeTitleOrName(Node node) {
+    try {
+      if (node.hasProperty("exo:title")) {
+        return node.getProperty("exo:title").getString();
+      }
+      return URLDecoder.decode(node.getName(), StandardCharsets.UTF_8);
+    } catch (RepositoryException e) {
+      try {
+        return node.getName();
+      } catch (RepositoryException re) {
+        return "document";
+      }
+    }
+  }
+
+  private String parentFolderIdOf(Node node, String documentId) {
+    try {
+      Node parent = node.getParent();
+      if (parent.isNodeType("mix:referenceable")) {
+        return parent.getUUID();
+      }
+    } catch (RepositoryException e) {
+      LOG.debug("Could not resolve the parent folder of node {}", documentId, e);
+    }
+    throw new IllegalArgumentException(("Could not determine the source folder of document %s; pass 'folder_id' "
+        + "explicitly to choose where the result is stored.").formatted(documentId));
+  }
+
+  private OfficeDocumentModel toModelFromNode(Node node, String documentId) {
+    String path = "";
+    String mimeType = "application/octet-stream";
+    String parentFolderId = null;
+    try {
+      path = node.getPath();
+    } catch (RepositoryException e) {
+      LOG.debug("Could not read path of node {}", documentId, e);
+    }
+    try {
+      mimeType = node.getNode("jcr:content").getProperty("jcr:mimeType").getString();
+    } catch (RepositoryException e) {
+      LOG.debug("Could not read mime type of node {}", documentId, e);
+    }
+    try {
+      Node parent = node.getParent();
+      if (parent != null && parent.isNodeType("mix:referenceable")) {
+        parentFolderId = parent.getUUID();
+      }
+    } catch (Exception e) {
+      LOG.debug("Could not read parent of node {}", documentId, e);
+    }
+    return new OfficeDocumentModel(documentId,
+                                   nodeTitleOrName(node),
+                                   path,
+                                   FILE_URL_FORMAT.formatted(documentId),
+                                   parentFolderId,
+                                   mimeType);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Storage (Documents import path, reused from the Documents add-on)
+  // ---------------------------------------------------------------------------
+
+  private OfficeDocumentModel importContent(String parentFolderId,
+                                            String fileName,
+                                            byte[] bytes) throws IllegalAccessException, ObjectNotFoundException {
+    if (bytes == null || bytes.length == 0) {
+      throw new IllegalArgumentException("The produced document is empty; there is nothing to store.");
+    }
+    getNode(parentFolderId);
+    String entryName = sanitizeFileName(fileName);
+    String ownerId = String.valueOf(getOwnerId(parentFolderId));
+    long userIdentityId = getCurrentUserIdentityId();
+    Set<String> beforeFileIds = currentChildFileIds(parentFolderId);
+    String uploadId = null;
+    try {
+      uploadId = materializeUpload(zipSingleEntry(entryName, bytes), entryName + ".zip");
+      documentFileService.importFiles(ownerId,
+                                      parentFolderId,
+                                      null,
+                                      uploadId,
+                                      "duplicate",
+                                      getCurrentUserAclIdentity(),
+                                      userIdentityId);
+      uploadId = null;
+    } catch (IllegalAccessException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not store the document '%s': %s".formatted(entryName, e.getMessage()));
+    } finally {
+      if (uploadId != null) {
+        releaseUpload(uploadId);
+      }
+    }
+    return findImportedDocument(parentFolderId, entryName, beforeFileIds);
+  }
+
+  private OfficeDocumentModel findImportedDocument(String parentFolderId,
+                                                   String fileName,
+                                                   Set<String> beforeFileIds) throws ObjectNotFoundException,
+                                                                              IllegalAccessException {
+    for (int attempt = 0; attempt < IMPORT_POLL_MAX_ATTEMPTS; attempt++) {
+      OfficeDocumentModel match = resolveAddedChildFile(parentFolderId, beforeFileIds);
+      if (match != null) {
+        return match;
+      }
+      sleepQuietly(IMPORT_POLL_INTERVAL_MS);
+    }
+    throw new IllegalStateException(("The document '%s' was created and is being stored in the background. "
+        + "Call get_documents_by_folder_id on folder %s in a few seconds to retrieve it.")
+        .formatted(fileName, parentFolderId));
+  }
+
+  private Set<String> currentChildFileIds(String folderId) throws ObjectNotFoundException, IllegalAccessException {
+    DocumentFolderFilter filter = new DocumentFolderFilter(folderId, null, null, null);
+    return documentFileService.getFolderChildNodes(filter, 0, IMPORT_POLL_PAGE_SIZE, getCurrentUserIdentityId())
+                              .stream()
+                              .filter(FileNode.class::isInstance)
+                              .map(AbstractNode::getId)
+                              .collect(Collectors.toSet());
+  }
+
+  private OfficeDocumentModel resolveAddedChildFile(String folderId,
+                                                    Set<String> beforeFileIds) throws ObjectNotFoundException,
+                                                                               IllegalAccessException {
+    DocumentFolderFilter filter = new DocumentFolderFilter(folderId, null, null, null);
+    List<AbstractNode> children = documentFileService.getFolderChildNodes(filter,
+                                                                          0,
+                                                                          IMPORT_POLL_PAGE_SIZE,
+                                                                          getCurrentUserIdentityId());
+    return children.stream()
+                   .filter(FileNode.class::isInstance)
+                   .map(FileNode.class::cast)
+                   .filter(file -> !beforeFileIds.contains(file.getId()))
+                   .reduce((first, second) -> second)
+                   .map(this::toModel)
+                   .orElse(null);
+  }
+
+  private OfficeDocumentModel toModel(FileNode fileNode) {
+    return new OfficeDocumentModel(fileNode.getId(),
+                                   fileNode.getName(),
+                                   fileNode.getPath(),
+                                   FILE_URL_FORMAT.formatted(fileNode.getId()),
+                                   fileNode.getParentFolderId(),
+                                   fileNode.getMimeType());
+  }
+
+  protected String materializeUpload(byte[] zipBytes, String zipName) {
+    return UploadToolUtils.materialize(uploadService, zipBytes, zipName, "application/zip");
+  }
+
+  protected void releaseUpload(String uploadId) {
+    UploadToolUtils.release(uploadService, uploadId);
+  }
+
+  private AbstractNode getNode(String documentId) throws IllegalAccessException, ObjectNotFoundException {
+    return documentFileService.getDocumentById(documentId, getCurrentUserName());
+  }
+
+  private long getOwnerId(String folderId) {
+    return documentFileService.getRootFolderOwnerId(folderId);
+  }
+
+  private long getCurrentUserIdentityId() {
+    return identityManager.getOrCreateUserIdentity(getCurrentUserName()).getIdentityId();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Small helpers
+  // ---------------------------------------------------------------------------
+
+  private static String appendExtension(String name, String type) {
+    String base = StringUtils.trimToEmpty(name);
+    String suffix = "." + type;
+    if (StringUtils.endsWithIgnoreCase(base, suffix)) {
+      base = base.substring(0, base.length() - suffix.length());
+    }
+    return base + suffix;
+  }
+
+  private static String stripExtension(String name) {
+    if (StringUtils.isBlank(name)) {
+      return "document";
+    }
+    int dot = name.lastIndexOf('.');
+    return dot > 0 ? name.substring(0, dot) : name;
+  }
+
+  private static String extensionOf(String name) {
+    if (StringUtils.isBlank(name)) {
+      return "docx";
+    }
+    int dot = name.lastIndexOf('.');
+    return dot > 0 && dot < name.length() - 1 ? name.substring(dot + 1).toLowerCase(java.util.Locale.ROOT) : "docx";
+  }
+
+  private static String normalizeExtension(String type) {
+    String t = StringUtils.lowerCase(StringUtils.trimToEmpty(type));
+    if (t.startsWith(".")) {
+      t = t.substring(1);
+    }
+    if (StringUtils.isBlank(t)) {
+      throw new IllegalArgumentException("The target format is empty.");
+    }
+    return t;
+  }
+
+  private static byte[] zipSingleEntry(String entryName, byte[] content) {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (ZipOutputStream zip = new ZipOutputStream(output)) {
+      zip.putNextEntry(new ZipEntry(entryName));
+      zip.write(content);
+      zip.closeEntry();
+    } catch (IOException e) {
+      throw new IllegalStateException("Could not package the document content: " + e.getMessage());
+    }
+    return output.toByteArray();
+  }
+
+  private static String sanitizeFileName(String fileName) {
+    String cleaned = StringUtils.trimToEmpty(fileName).replaceAll("[/\\\\]", "_");
+    return cleaned.isEmpty() ? "document" : cleaned;
+  }
+
+  private static void sleepQuietly(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Holds a user {@link SessionProvider} and its opened {@link Session}; closing
+   * it releases the provider.
+   */
+  protected static final class UserSession {
+
+    private final SessionProvider provider;
+
+    private final Session         session;
+
+    protected UserSession(SessionProvider provider, Session session) {
+      this.provider = provider;
+      this.session = session;
+    }
+
+    protected Session session() {
+      return session;
+    }
+
+    protected void close() {
+      if (provider != null) {
+        provider.close();
+      }
+    }
+  }
+
+}

--- a/services/src/main/java/org/exoplatform/onlyoffice/mcp/model/OfficeDocumentModel.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/mcp/model/OfficeDocumentModel.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2003-2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.onlyoffice.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Result returned by the office document creation / conversion MCP tools: the
+ * newly stored file's id and name (mirrors the shape returned by the Documents
+ * add-on {@code DocumentMcpTool}), plus its path, in-app URL and mime type.
+ */
+@JsonInclude(Include.NON_EMPTY)
+public class OfficeDocumentModel {
+
+  @JsonProperty("document_id")
+  private final String id;
+
+  private final String name;
+
+  private final String path;
+
+  private final String url;
+
+  @JsonProperty("parent_folder_id")
+  private final String parentFolderId;
+
+  @JsonProperty("mime_type")
+  private final String mimeType;
+
+  public OfficeDocumentModel(String id, String name, String path, String url, String parentFolderId, String mimeType) {
+    this.id = id;
+    this.name = name;
+    this.path = path;
+    this.url = url;
+    this.parentFolderId = parentFolderId;
+    this.mimeType = mimeType;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public String getParentFolderId() {
+    return parentFolderId;
+  }
+
+  public String getMimeType() {
+    return mimeType;
+  }
+
+}

--- a/services/src/main/java/org/exoplatform/onlyoffice/mcp/model/OfficeEditorLinkModel.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/mcp/model/OfficeEditorLinkModel.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2003-2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.onlyoffice.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Result returned by {@code get_document_editor_link}: the ONLYOFFICE online
+ * editor URL for a document, together with its id and name.
+ */
+@JsonInclude(Include.NON_EMPTY)
+public class OfficeEditorLinkModel {
+
+  @JsonProperty("document_id")
+  private final String id;
+
+  private final String name;
+
+  @JsonProperty("editor_url")
+  private final String editorUrl;
+
+  public OfficeEditorLinkModel(String id, String name, String editorUrl) {
+    this.id = id;
+    this.name = name;
+    this.editorUrl = editorUrl;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getEditorUrl() {
+    return editorUrl;
+  }
+
+}

--- a/services/src/main/java/org/exoplatform/onlyoffice/rest/EditorService.java
+++ b/services/src/main/java/org/exoplatform/onlyoffice/rest/EditorService.java
@@ -322,6 +322,11 @@ public class EditorService implements ResourceContainer {
         String token = request.getHeader("Authorization");
         if (token != null) {
           token = token.replace("Bearer", "").trim();
+        } else {
+          // The Document Server fetches in-script Document Builder asset URLs
+          // (OpenFile / CreateImage) without an Authorization header, so the
+          // signed token is carried as a query parameter for those fetches.
+          token = uriInfo.getQueryParameters().getFirst("token");
         }
         if (editors.validateToken(token, key)) {
           try {

--- a/services/src/main/resources/ai-tool-definitions.json
+++ b/services/src/main/resources/ai-tool-definitions.json
@@ -1,0 +1,249 @@
+{
+  "tools": [
+    {
+      "name": "edit_spreadsheet",
+      "title": "Create or modify a spreadsheet (xlsx)",
+      "description": "Creates a new Excel spreadsheet (xlsx) or modifies an existing one via the ONLYOFFICE Document Builder. Pass 'document_id' to MODIFY an existing spreadsheet (the change is saved back as a new version); or pass 'parent_folder_id' and 'name' to CREATE a new spreadsheet in the user's drive. Get parent_folder_id from get_root_folder_for_user, get_root_folder_by_space or get_documents_by_folder_id, and document_id from get_document_by_id / get_documents_by_folder_id. The 'operations' argument is a JSON ARRAY STRING (parsed server-side) of these operation objects: {\"type\":\"set_cells\",\"start\":\"A1\",\"values\":[[\"Region\",\"Sales\"],[\"North\",120]]} writes a 2D block anchored at a cell; {\"type\":\"set_formula\",\"cell\":\"B4\",\"formula\":\"=SUM(B2:B3)\"}; {\"type\":\"add_chart\",\"chart\":\"bar|line|pie\",\"range\":\"Sheet1!$A$1:$B$3\",\"title\":\"Sales\"}; {\"type\":\"add_sheet\",\"name\":\"Q3\"} (subsequent operations target the new sheet). Requires the ONLYOFFICE Document Server to be installed and running.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "description": "The JCR uuid of an existing spreadsheet to modify. Omit to create a new spreadsheet."
+          },
+          "parent_folder_id": {
+            "type": "string",
+            "description": "The folder where a new spreadsheet is created (create mode). Required when document_id is not given."
+          },
+          "name": {
+            "type": "string",
+            "description": "The new spreadsheet name WITHOUT extension (create mode); '.xlsx' is appended automatically."
+          },
+          "operations": {
+            "type": "string",
+            "description": "A JSON array string of spreadsheet operations (set_cells, set_formula, add_chart, add_sheet)."
+          }
+        },
+        "required": [
+          "operations"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "edit_presentation",
+      "title": "Create or modify a presentation (pptx)",
+      "description": "Creates a new PowerPoint presentation (pptx) or modifies an existing one via the ONLYOFFICE Document Builder. Pass 'document_id' to MODIFY (saved back as a new version), or 'parent_folder_id' and 'name' to CREATE a new presentation. The 'operations' argument is a JSON ARRAY STRING (parsed server-side) of these operation objects: {\"type\":\"add_slide\",\"layout\":\"title|content|closing\",\"title\":\"Quarterly Review\",\"bullets\":[\"Revenue up 20%\",\"Two new markets\"]} appends a slide with a title and bullet lines; {\"type\":\"set_slide\",\"index\":0,\"title\":\"...\",\"bullets\":[...]} replaces the content of the slide at that 0-based index; {\"type\":\"add_image\",\"slide\":1,\"url\":\"https://.../pic.png\"} or {\"type\":\"add_image\",\"slide\":1,\"document_id\":\"<uuid>\"} adds an image (from an http(s) URL or a DMS image file) onto a slide. To embed an image the user attached in this chat (or refers to as 'this image'/'the image'), emit an add_image op WITHOUT url and WITHOUT document_id (e.g. {\"type\":\"add_image\",\"slide\":1}) and leave the top-level attachment_object_type/attachment_object_id parameters to be filled from the attachment. NEVER invent, guess, or use a placeholder url (e.g. https://example.com/...) for an attached image — omit url/document_id entirely. Requires the ONLYOFFICE Document Server to be installed and running.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "description": "The JCR uuid of an existing presentation to modify. Omit to create a new presentation."
+          },
+          "parent_folder_id": {
+            "type": "string",
+            "description": "The folder where a new presentation is created (create mode). Required when document_id is not given."
+          },
+          "name": {
+            "type": "string",
+            "description": "The new presentation name WITHOUT extension (create mode); '.pptx' is appended automatically."
+          },
+          "operations": {
+            "type": "string",
+            "description": "A JSON array string of presentation operations (add_slide, set_slide, add_image)."
+          },
+          "attachment_object_type": {
+            "type": "string",
+            "description": "Object type of an image the user attached in the chat; auto-filled by the assistant. Used as the image source for any add_image op that has no url/document_id."
+          },
+          "attachment_object_id": {
+            "type": "string",
+            "description": "Object id of an image the user attached in the chat; auto-filled by the assistant. Paired with attachment_object_type."
+          }
+        },
+        "required": [
+          "operations"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "edit_document",
+      "title": "Create or modify a text document (docx)",
+      "description": "Creates a new Word document (docx) or modifies an existing one via the ONLYOFFICE Document Builder. Pass 'document_id' to MODIFY (saved back as a new version), or 'parent_folder_id' and 'name' to CREATE a new document. The 'operations' argument is a JSON ARRAY STRING (parsed server-side) of these operation objects: {\"type\":\"add_heading\",\"level\":1,\"text\":\"...\"}; {\"type\":\"add_paragraph\",\"text\":\"...\",\"bold\":false,\"italic\":false}; {\"type\":\"add_table\",\"rows\":[[\"Item\",\"Value\"],[\"Total\",\"42000\"]]}; {\"type\":\"add_image\",\"url\":\"https://.../pic.png\"} or {\"type\":\"add_image\",\"document_id\":\"<uuid>\"}; {\"type\":\"replace_text\",\"search\":\"{{name}}\",\"replace\":\"ACME\"}. To embed an image the user attached in this chat (or refers to as 'this image'/'the image'), emit an add_image op WITHOUT url and WITHOUT document_id (e.g. {\"type\":\"add_image\"}) and leave the top-level attachment_object_type/attachment_object_id parameters to be filled from the attachment. NEVER invent, guess, or use a placeholder url (e.g. https://example.com/...) for an attached image — omit url/document_id entirely. To author a whole document from rich HTML instead, send a single {\"type\":\"set_html\",\"html\":\"<h1>..</h1>\"} operation (CREATE only; it uses the HTML->docx conversion API and cannot be combined with other operations). Requires the ONLYOFFICE Document Server to be installed and running.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "description": "The JCR uuid of an existing document to modify. Omit to create a new document."
+          },
+          "parent_folder_id": {
+            "type": "string",
+            "description": "The folder where a new document is created (create mode). Required when document_id is not given."
+          },
+          "name": {
+            "type": "string",
+            "description": "The new document name WITHOUT extension (create mode); '.docx' is appended automatically."
+          },
+          "operations": {
+            "type": "string",
+            "description": "A JSON array string of document operations (add_heading, add_paragraph, add_table, add_image, replace_text, or a single set_html)."
+          },
+          "attachment_object_type": {
+            "type": "string",
+            "description": "Object type of an image the user attached in the chat; auto-filled by the assistant. Used as the image source for any add_image op that has no url/document_id."
+          },
+          "attachment_object_id": {
+            "type": "string",
+            "description": "Object id of an image the user attached in the chat; auto-filled by the assistant. Paired with attachment_object_type."
+          }
+        },
+        "required": [
+          "operations"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "generate_document",
+      "title": "Generate a document from a template",
+      "description": "Generates a new document from a template document by replacing every placeholder with its value (a template-fill / mail-merge run through the ONLYOFFICE Document Builder). Use this when you have a reusable template (e.g. a contract or proposal docx containing {{client}}, {{amount}} placeholders) and a set of values to fill in. The 'data' argument is a JSON OBJECT STRING mapping each placeholder to its replacement, e.g. {\"{{client}}\":\"ACME Corp\",\"{{amount}}\":\"42,000 EUR\"}. The produced file is stored as a new document (it does not overwrite the template). Requires the ONLYOFFICE Document Server to be installed and running.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "template_document_id": {
+            "type": "string",
+            "description": "The JCR uuid of the template document (e.g. a docx with {{placeholder}} markers)."
+          },
+          "folder_id": {
+            "type": "string",
+            "description": "Optional destination folder for the generated document. Defaults to the template's own folder."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional produced document name WITHOUT extension. Defaults to the template name."
+          },
+          "data": {
+            "type": "string",
+            "description": "A JSON object string mapping each placeholder to its replacement value."
+          }
+        },
+        "required": [
+          "template_document_id",
+          "data"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "convert_document",
+      "title": "Convert a document to another format",
+      "description": "Converts an existing office document to another format using the ONLYOFFICE Document Server, storing the result as '<originalName>.<target_format>'. Use this to turn a docx into odt, an xlsx into csv, a pptx into pdf, etc. By default the result is stored in the same folder as the source; pass folder_id to store it elsewhere. Call get_document_by_id or get_documents_by_folder_id first to get the document_id. Requires the ONLYOFFICE Document Server to be installed and running.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "description": "The JCR uuid of the source document to convert."
+          },
+          "target_format": {
+            "type": "string",
+            "description": "The produced format, e.g. docx, xlsx, pptx, odt, ods, odp, csv, txt, pdf."
+          },
+          "folder_id": {
+            "type": "string",
+            "description": "Optional destination folder for the converted file. Defaults to the source document's own folder."
+          }
+        },
+        "required": [
+          "document_id",
+          "target_format"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "export_document_as_pdf",
+      "title": "Export a document as PDF",
+      "description": "Exports an existing office document as a PDF using the ONLYOFFICE Document Server, storing the result as '<originalName>.pdf'. By default the PDF is stored in the same folder as the source document; pass parent_folder_id to store it elsewhere. Call get_document_by_id or get_documents_by_folder_id first to get the document_id. Requires the ONLYOFFICE Document Server to be installed and running.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "description": "The JCR uuid of the source document to export as PDF."
+          },
+          "parent_folder_id": {
+            "type": "string",
+            "description": "Optional destination folder id for the produced PDF. Defaults to the source document's own folder."
+          }
+        },
+        "required": [
+          "document_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "get_document_editor_link",
+      "title": "Get the online editor link of a document",
+      "description": "Returns the ONLYOFFICE online editor URL of a document so it can be opened for editing. The user must have edit permission on the document and it must be an editable office document. Call get_document_by_id or get_documents_by_folder_id first to get the document_id.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "description": "The JCR uuid of the document to open in the online editor."
+          }
+        },
+        "required": [
+          "document_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    }
+  ]
+}

--- a/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
+++ b/services/src/test/java/org/exoplatform/onlyoffice/OnlyofficeEditorServiceTest.java
@@ -1762,4 +1762,64 @@ public class OnlyofficeEditorServiceTest extends BaseCommonsTestCase {
     node.remove();
   }
 
+  /**
+   * Regression test for the MCP MODIFY versioning bug: saveNewVersion() on a
+   * versionable document that is left checked-in (the normal persisted state once
+   * a version exists) must make the NEW bytes the CURRENT/displayed content, not
+   * only add them to the version history while the live node stays on the prior
+   * version. Mirrors the editor save-back path which checks the node out before
+   * updating jcr:data and creating the version.
+   */
+  @Test
+  public void testSaveNewVersionAdvancesCurrentContentOnCheckedInNode() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Modify Version Test.docx", "nt:file", "v1-original-content", true);
+    String nodePath = node.getPath();
+
+    // Establish a prior version (v1) and leave the node checked-in, exactly the
+    // state in which the old saveNewVersion() failed to advance the current content.
+    node.checkin();
+    assertFalse("Precondition: the node must be checked-in before the modify", node.isCheckedOut());
+
+    byte[] newBytes = "v2-timeline-new-content".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    onlyofficeEditorService.saveNewVersion(node, newBytes, USER_USERNAME);
+
+    // Reload from the workspace to read the CURRENT (displayed) content.
+    Node reloaded = editorService.getDocument(null, nodePath);
+    String currentContent = reloaded.getNode("jcr:content").getProperty("jcr:data").getString();
+    assertEquals("saveNewVersion must make the new bytes the current/displayed content",
+                 "v2-timeline-new-content",
+                 currentContent);
+
+    // The prior content must be preserved as an older version, and the new content
+    // is now the base (current) version.
+    javax.jcr.version.VersionHistory vh = reloaded.getVersionHistory();
+    assertTrue("A prior version must be preserved in history (root + v1 [+ new])",
+               vh.getAllVersions().getSize() >= 2);
+
+    node.remove();
+  }
+
+  /**
+   * saveNewVersion() on a checked-out versionable node (e.g. right after a previous
+   * edit) must still make the new bytes current and create a new version.
+   */
+  @Test
+  public void testSaveNewVersionAdvancesCurrentContentOnCheckedOutNode() throws Exception {
+    startSessionAs(USER_USERNAME);
+    Node node = createDocument("Modify Version Test2.docx", "nt:file", "original", true);
+    String nodePath = node.getPath();
+    assertTrue("Precondition: freshly versionable node is checked-out", node.isCheckedOut());
+
+    byte[] newBytes = "brand-new-bytes".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    onlyofficeEditorService.saveNewVersion(node, newBytes, USER_USERNAME);
+
+    Node reloaded = editorService.getDocument(null, nodePath);
+    assertEquals("New bytes must be the current content",
+                 "brand-new-bytes",
+                 reloaded.getNode("jcr:content").getProperty("jcr:data").getString());
+
+    node.remove();
+  }
+
 }

--- a/services/src/test/java/org/exoplatform/onlyoffice/mcp/OnlyofficeMcpToolTest.java
+++ b/services/src/test/java/org/exoplatform/onlyoffice/mcp/OnlyofficeMcpToolTest.java
@@ -1,0 +1,622 @@
+/*
+ * Copyright (C) 2003-2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.onlyoffice.mcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.documents.model.AbstractNode;
+import org.exoplatform.documents.model.FileNode;
+import org.exoplatform.documents.service.DocumentFileService;
+import org.exoplatform.onlyoffice.OnlyofficeEditorService;
+import org.exoplatform.onlyoffice.mcp.OnlyofficeMcpTool.UserSession;
+import org.exoplatform.onlyoffice.mcp.model.OfficeDocumentModel;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.attachment.AttachmentService;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.upload.UploadService;
+
+/**
+ * Mockito unit tests for {@link OnlyofficeMcpTool}. The user JCR session, the
+ * shared {@code runDocBuilderScript} primitive and the static upload helper are
+ * stubbed through the tool's protected seams so every tool's orchestration, its
+ * Document Builder script generation and its error mapping can be exercised
+ * without a live Document Server or JCR.
+ * <p>
+ * <b>Golden-string tests.</b> The {@code goldenScript_*} tests below are
+ * regression guards: they pin the <i>exact</i> Document Builder JavaScript the
+ * generators emit for representative inputs (captured via an {@code
+ * ArgumentCaptor} on the mocked {@code runDocBuilderScript}). They protect the
+ * verified-correct emission — notably {@code Api.CreateTable(rowCount, colCount)}
+ * (rows first) — from silent regressions. They do NOT prove the emitted API is
+ * accepted by a Document Server: true API-correctness (arg order, method names,
+ * signatures) was validated manually by running each generated script through a
+ * live Document Server docbuilder endpoint and asserting a valid OOXML result
+ * with the expected content. Re-run that DS integration check whenever a
+ * generator's emitted API surface changes.
+ */
+public class OnlyofficeMcpToolTest {
+
+  private static final String     USER = "john";
+
+  private OnlyofficeEditorService editorService;
+
+  private DocumentFileService     documentFileService;
+
+  private IdentityManager         identityManager;
+
+  private UserACL                 userAcl;
+
+  private RepositoryService       repositoryService;
+
+  private UploadService           uploadService;
+
+  private AttachmentService       attachmentService;
+
+  private FileService             fileService;
+
+  private OnlyofficeMcpTool       tool;
+
+  private Session                 session;
+
+  @Before
+  public void setUp() {
+    editorService = mock(OnlyofficeEditorService.class);
+    documentFileService = mock(DocumentFileService.class);
+    identityManager = mock(IdentityManager.class);
+    userAcl = mock(UserACL.class);
+    repositoryService = mock(RepositoryService.class);
+    uploadService = mock(UploadService.class);
+    attachmentService = mock(AttachmentService.class);
+    fileService = mock(FileService.class);
+
+    tool = spy(new OnlyofficeMcpTool(editorService,
+                                     documentFileService,
+                                     identityManager,
+                                     userAcl,
+                                     repositoryService,
+                                     uploadService,
+                                     attachmentService,
+                                     fileService));
+
+    ConversationState.setCurrent(new ConversationState(new Identity(USER)));
+
+    org.exoplatform.social.core.identity.model.Identity socialIdentity =
+                                                                       mock(org.exoplatform.social.core.identity.model.Identity.class);
+    when(socialIdentity.getIdentityId()).thenReturn(1L);
+    when(identityManager.getOrCreateUserIdentity(USER)).thenReturn(socialIdentity);
+
+    session = mock(Session.class);
+    SessionProvider provider = mock(SessionProvider.class);
+    doReturn(new UserSession(provider, session)).when(tool).openUserSession();
+    doReturn("upload-1").when(tool).materializeUpload(any(byte[].class), anyString());
+  }
+
+  @After
+  public void tearDown() {
+    ConversationState.setCurrent(null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // edit_spreadsheet
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void editSpreadsheet_create_generatesCreateScript_andStoresFile() throws Exception {
+    Node parent = mock(Node.class);
+    when(session.getNodeByUUID("folder-1")).thenReturn(parent);
+    stubStorage("folder-1", "budget.xlsx", "new-xlsx-id");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("xlsx"), eq("result.xlsx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 1, 2, 3 });
+
+    String ops = "[{\"type\":\"set_cells\",\"start\":\"A1\",\"values\":[[\"Region\",\"Sales\"],[\"North\",120]]},"
+        + "{\"type\":\"set_formula\",\"cell\":\"B3\",\"formula\":\"=SUM(B2:B2)\"},"
+        + "{\"type\":\"add_chart\",\"chart\":\"bar\",\"range\":\"Sheet1!$A$1:$B$2\",\"title\":\"Sales\"}]";
+    OfficeDocumentModel result = tool.editSpreadsheet(null, "folder-1", "budget", ops);
+
+    assertNotNull(result);
+    assertEquals("new-xlsx-id", result.getId());
+    assertEquals("budget.xlsx", result.getName());
+
+    String script = captureScript("xlsx", "result.xlsx");
+    assertTrue(script.contains("builder.CreateFile(\"xlsx\")"));
+    assertTrue(script.contains("GetRangeByNumber(0, 0).SetValue(\"Region\")"));
+    assertTrue(script.contains("SetValue(120)"));
+    assertTrue(script.contains(".SetValue(\"=SUM(B2:B2)\")"));
+    assertTrue(script.contains("AddChart(\"Sheet1!$A$1:$B$2\", true, \"bar\""));
+    assertTrue(script.contains("builder.SaveFile(\"xlsx\", \"result.xlsx\")"));
+  }
+
+  @Test
+  public void editSpreadsheet_modify_opensFile_andSavesNewVersion() throws Exception {
+    Node node = stubExistingDocument("xlsx-1", "budget.xlsx",
+                                     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("xlsx"), eq("result.xlsx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 9 });
+
+    String ops = "[{\"type\":\"add_sheet\",\"name\":\"Q3\"}]";
+    OfficeDocumentModel result = tool.editSpreadsheet("xlsx-1", null, null, ops);
+
+    assertNotNull(result);
+    assertEquals("xlsx-1", result.getId());
+    verify(editorService).saveNewVersion(eq(node), any(byte[].class), eq(USER));
+
+    String script = captureScript("xlsx", "result.xlsx");
+    assertTrue(script.contains("builder.OpenFile(\"@@ASSET:input@@\", \"\")"));
+    assertTrue(script.contains("Api.AddSheet(\"Q3\")"));
+  }
+
+  @Test
+  public void editSpreadsheet_failedBuild_throwsIllegalState() throws Exception {
+    Node parent = mock(Node.class);
+    when(session.getNodeByUUID("folder-1")).thenReturn(parent);
+    when(editorService.runDocBuilderScript(anyString(), any(), anyString(), anyString(), eq(USER))).thenReturn(null);
+
+    IllegalStateException e = assertThrows(IllegalStateException.class,
+                                           () -> tool.editSpreadsheet(null,
+                                                                      "folder-1",
+                                                                      "budget",
+                                                                      "[{\"type\":\"add_sheet\",\"name\":\"S\"}]"));
+    assertTrue(e.getMessage().contains("Document Server"));
+  }
+
+  @Test
+  public void editSpreadsheet_neitherIdNorFolder_throwsIllegalArgument() {
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.editSpreadsheet(null, null, null, "[{\"type\":\"add_sheet\",\"name\":\"S\"}]"));
+  }
+
+  @Test
+  public void editSpreadsheet_badOperationsJson_throwsIllegalArgument() {
+    assertThrows(IllegalArgumentException.class, () -> tool.editSpreadsheet(null, "folder-1", "b", "not json"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // edit_presentation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void editPresentation_create_generatesSlideScript() throws Exception {
+    Node parent = mock(Node.class);
+    when(session.getNodeByUUID("folder-1")).thenReturn(parent);
+    stubStorage("folder-1", "deck.pptx", "new-pptx-id");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("pptx"), eq("result.pptx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 7 });
+
+    String ops = "[{\"type\":\"add_slide\",\"title\":\"Review\",\"bullets\":[\"One\",\"Two\"]}]";
+    OfficeDocumentModel result = tool.editPresentation(null, "folder-1", "deck", ops, null, null);
+
+    assertEquals("new-pptx-id", result.getId());
+    String script = captureScript("pptx", "result.pptx");
+    assertTrue(script.contains("builder.CreateFile(\"pptx\")"));
+    // On CREATE the first add_slide populates the blank default slide that
+    // builder.CreateFile("pptx") already produced, instead of appending a new one.
+    assertTrue(script.contains("oPresentation.GetSlideByIndex(0)"));
+    assertTrue(script.contains("__setSlideText(oSlide, \"Review\", [\"One\", \"Two\"])"));
+  }
+
+  @Test
+  public void editPresentation_modify_opensFile_andSavesNewVersion() throws Exception {
+    Node node = stubExistingDocument("pptx-1", "deck.pptx",
+                                     "application/vnd.openxmlformats-officedocument.presentationml.presentation");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("pptx"), eq("result.pptx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 3 });
+
+    OfficeDocumentModel result = tool.editPresentation("pptx-1", null, null,
+                                                       "[{\"type\":\"set_slide\",\"index\":0,\"title\":\"Hi\"}]", null, null);
+
+    assertEquals("pptx-1", result.getId());
+    verify(editorService).saveNewVersion(eq(node), any(byte[].class), eq(USER));
+    String script = captureScript("pptx", "result.pptx");
+    assertTrue(script.contains("builder.OpenFile(\"@@ASSET:input@@\", \"\")"));
+    assertTrue(script.contains("GetSlideByIndex(0)"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // edit_document
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void editDocument_create_generatesStructuredScript() throws Exception {
+    Node parent = mock(Node.class);
+    when(session.getNodeByUUID("folder-1")).thenReturn(parent);
+    stubStorage("folder-1", "report.docx", "new-docx-id");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("docx"), eq("result.docx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 5 });
+
+    String ops = "[{\"type\":\"add_heading\",\"level\":1,\"text\":\"Title\"},"
+        + "{\"type\":\"add_paragraph\",\"text\":\"Body\"},"
+        + "{\"type\":\"add_table\",\"rows\":[[\"A\",\"B\"],[\"1\",\"2\"]]},"
+        + "{\"type\":\"replace_text\",\"search\":\"{{x}}\",\"replace\":\"y\"}]";
+    OfficeDocumentModel result = tool.editDocument(null, "folder-1", "report", ops, null, null);
+
+    assertEquals("new-docx-id", result.getId());
+    String script = captureScript("docx", "result.docx");
+    assertTrue(script.contains("builder.CreateFile(\"docx\")"));
+    assertTrue(script.contains("oR.AddText(\"Title\"); oR.SetBold(true)"));
+    assertTrue(script.contains("Api.CreateTable(2, 2)"));
+    assertTrue(script.contains("SearchAndReplace({\"searchString\":\"{{x}}\", \"replaceString\":\"y\"})"));
+  }
+
+  @Test
+  public void editDocument_modify_opensFile_andSavesNewVersion() throws Exception {
+    Node node = stubExistingDocument("docx-1", "report.docx",
+                                     "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("docx"), eq("result.docx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 2 });
+
+    OfficeDocumentModel result = tool.editDocument("docx-1", null, null,
+                                                   "[{\"type\":\"add_paragraph\",\"text\":\"More\"}]", null, null);
+
+    assertEquals("docx-1", result.getId());
+    verify(editorService).saveNewVersion(eq(node), any(byte[].class), eq(USER));
+    String script = captureScript("docx", "result.docx");
+    assertTrue(script.contains("builder.OpenFile(\"@@ASSET:input@@\", \"\")"));
+  }
+
+  @Test
+  public void editDocument_setHtml_create_usesConversionPath() throws Exception {
+    Node parent = mock(Node.class);
+    when(session.getNodeByUUID("folder-1")).thenReturn(parent);
+    stubTempNodeCreation(parent);
+    Node tmp = parent.addNode("x", "nt:file");
+    when(editorService.convertNodeContent(eq(tmp), eq("docx"), eq("html"), eq(USER))).thenReturn(new byte[] { 1 });
+    stubStorage("folder-1", "page.docx", "html-docx-id");
+
+    OfficeDocumentModel result = tool.editDocument(null,
+                                                   "folder-1",
+                                                   "page",
+                                                   "[{\"type\":\"set_html\",\"html\":\"<h1>Hi</h1>\"}]",
+                                                   null,
+                                                   null);
+
+    assertEquals("html-docx-id", result.getId());
+    verify(editorService).convertNodeContent(eq(tmp), eq("docx"), eq("html"), eq(USER));
+  }
+
+  @Test
+  public void editDocument_setHtml_withDocumentId_throwsIllegalArgument() {
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.editDocument("doc-1", null, null, "[{\"type\":\"set_html\",\"html\":\"<p>x</p>\"}]", null, null));
+  }
+
+  @Test
+  public void editDocument_setHtml_mixedWithStructured_throwsIllegalArgument() {
+    String ops = "[{\"type\":\"set_html\",\"html\":\"<p>x</p>\"},{\"type\":\"add_paragraph\",\"text\":\"y\"}]";
+    assertThrows(IllegalArgumentException.class, () -> tool.editDocument(null, "folder-1", "p", ops, null, null));
+  }
+
+  @Test
+  public void editDocument_unsupportedOperation_throwsIllegalArgument() {
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.editDocument(null, "folder-1", "p", "[{\"type\":\"add_footnote\",\"text\":\"x\"}]", null, null));
+  }
+
+  // ---------------------------------------------------------------------------
+  // generate_document
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void generateDocument_fillsTemplate_andStoresNewFile() throws Exception {
+    Node template = stubExistingDocument("tpl-1", "contract.docx",
+                                         "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    Node templateParent = mock(Node.class);
+    when(template.getParent()).thenReturn(templateParent);
+    when(templateParent.isNodeType("mix:referenceable")).thenReturn(true);
+    when(templateParent.getUUID()).thenReturn("tpl-folder");
+    stubStorage("out-folder", "filled.docx", "gen-id");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("docx"), eq("result.docx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 4 });
+
+    OfficeDocumentModel result = tool.generateDocument("tpl-1",
+                                                       "out-folder",
+                                                       "filled",
+                                                       "{\"{{client}}\":\"ACME\",\"{{amount}}\":\"42000\"}");
+
+    assertEquals("gen-id", result.getId());
+    String script = captureScript("docx", "result.docx");
+    assertTrue(script.contains("builder.OpenFile(\"@@ASSET:input@@\", \"\")"));
+    assertTrue(script.contains("SearchAndReplace({\"searchString\":\"{{client}}\", \"replaceString\":\"ACME\"})"));
+  }
+
+  @Test
+  public void generateDocument_blankData_throwsIllegalArgument() {
+    assertThrows(IllegalArgumentException.class, () -> tool.generateDocument("tpl-1", null, null, "{}"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // convert_document
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void convertDocument_convertsAndStores() throws Exception {
+    Node node = stubExistingDocument("doc-1", "report.docx",
+                                     "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    Node parent = mock(Node.class);
+    when(node.getParent()).thenReturn(parent);
+    when(parent.isNodeType("mix:referenceable")).thenReturn(true);
+    when(parent.getUUID()).thenReturn("src-folder");
+    stubStorage("src-folder", "report.odt", "odt-id");
+    when(editorService.convertNodeContent(eq(node), eq("odt"), eq("docx"), eq(USER))).thenReturn(new byte[] { 8 });
+
+    OfficeDocumentModel result = tool.convertDocument("doc-1", "odt", null);
+
+    assertEquals("odt-id", result.getId());
+    assertEquals("report.odt", result.getName());
+  }
+
+  @Test
+  public void convertDocument_nullConversion_throwsIllegalState() throws Exception {
+    Node node = stubExistingDocument("doc-1", "report.docx",
+                                     "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    Node parent = mock(Node.class);
+    when(node.getParent()).thenReturn(parent);
+    when(parent.isNodeType("mix:referenceable")).thenReturn(true);
+    when(parent.getUUID()).thenReturn("src-folder");
+    when(editorService.convertNodeContent(eq(node), eq("odt"), anyString(), eq(USER))).thenReturn(null);
+
+    IllegalStateException e = assertThrows(IllegalStateException.class, () -> tool.convertDocument("doc-1", "odt", null));
+    assertTrue(e.getMessage().contains("Document Server"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // export_document_as_pdf
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void exportDocumentAsPdf_happyPath_storesPdf() throws Exception {
+    Node node = stubExistingDocument("doc-1", "Quarter.docx",
+                                     "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    when(editorService.convertNodeContentToPdf(node, USER)).thenReturn(new byte[] { 9 });
+    stubStorage("target-folder", "Quarter.pdf", "pdf-doc-id");
+
+    OfficeDocumentModel result = tool.exportDocumentAsPdf("doc-1", "target-folder");
+
+    assertNotNull(result);
+    assertEquals("pdf-doc-id", result.getId());
+    assertEquals("Quarter.pdf", result.getName());
+  }
+
+  @Test
+  public void exportDocumentAsPdf_blankId_throwsIllegalArgument() {
+    assertThrows(IllegalArgumentException.class, () -> tool.exportDocumentAsPdf("  ", null));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Golden-string regression guards (exact emitted Document Builder script).
+  // These pin the DS-verified emission; they run with NO Document Server.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * add_table with 3 data rows + a header (4 total) x 3 columns must emit
+   * {@code Api.CreateTable(rowCount, colCount)} = {@code (4, 3)} (rows first) and
+   * address the last cell as {@code GetRow(3).GetCell(2)}. This is the exact bug
+   * the DS check caught: emitting {@code (colCount, rowCount)} built a 3-row table
+   * and {@code GetRow(3)} threw "Row index out of bounds".
+   */
+  @Test
+  public void goldenScript_addTable_rowsFirst_and_lastCellAddressing() throws Exception {
+    Node parent = mock(Node.class);
+    when(session.getNodeByUUID("folder-1")).thenReturn(parent);
+    stubStorage("folder-1", "report.docx", "docx-id");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("docx"), eq("result.docx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 1 });
+
+    String ops = "[{\"type\":\"add_table\",\"rows\":["
+        + "[\"H1\",\"H2\",\"H3\"],[\"a\",\"b\",\"c\"],[\"d\",\"e\",\"f\"],[\"g\",\"h\",\"i\"]]}]";
+    tool.editDocument(null, "folder-1", "report", ops, null, null);
+
+    String script = captureScript("docx", "result.docx");
+    assertTrue("rows-first CreateTable(4, 3)", script.contains("Api.CreateTable(4, 3)"));
+    assertTrue("last cell GetRow(3).GetCell(2)", script.contains("oTable.GetRow(3).GetCell(2)"));
+    assertTrue("header cell text", script.contains("oTable.GetRow(0).GetCell(0).GetContent().GetElement(0).AddText(\"H1\")"));
+    assertTrue("last cell text", script.contains("oTable.GetRow(3).GetCell(2).GetContent().GetElement(0).AddText(\"i\")"));
+    assertTrue("table width", script.contains("oTable.SetWidth(\"percent\", 100)"));
+    assertTrue("table pushed", script.contains("oDocument.Push(oTable)"));
+  }
+
+  /**
+   * set_cells over a 2x2 range starting at A1 must emit 0-based
+   * {@code GetRangeByNumber(row, col)} calls (row first), one per cell, with
+   * numeric values unquoted.
+   */
+  @Test
+  public void goldenScript_setCells_rangeByNumberRowColOrder() throws Exception {
+    Node parent = mock(Node.class);
+    when(session.getNodeByUUID("folder-1")).thenReturn(parent);
+    stubStorage("folder-1", "grid.xlsx", "xlsx-id");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("xlsx"), eq("result.xlsx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 1 });
+
+    String ops = "[{\"type\":\"set_cells\",\"start\":\"A1\",\"values\":[[\"Region\",\"Sales\"],[\"North\",120]]}]";
+    tool.editSpreadsheet(null, "folder-1", "grid", ops);
+
+    String script = captureScript("xlsx", "result.xlsx");
+    assertTrue(script.contains("oWorksheet.GetRangeByNumber(0, 0).SetValue(\"Region\")"));
+    assertTrue(script.contains("oWorksheet.GetRangeByNumber(0, 1).SetValue(\"Sales\")"));
+    assertTrue(script.contains("oWorksheet.GetRangeByNumber(1, 0).SetValue(\"North\")"));
+    assertTrue(script.contains("oWorksheet.GetRangeByNumber(1, 1).SetValue(120)"));
+  }
+
+  /**
+   * add_chart must emit the DS-verified 10-argument {@code AddChart} signature:
+   * {@code (range, true, type, styleIndex=2, extX, extY, fromCol, colOff, fromRow,
+   * rowOff)} where extX/extY are EMU (100*36000 / 70*36000).
+   */
+  @Test
+  public void goldenScript_addChart_tenArgSignature() throws Exception {
+    Node parent = mock(Node.class);
+    when(session.getNodeByUUID("folder-1")).thenReturn(parent);
+    stubStorage("folder-1", "chart.xlsx", "xlsx-id");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("xlsx"), eq("result.xlsx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 1 });
+
+    String ops = "[{\"type\":\"add_chart\",\"chart\":\"bar\",\"range\":\"Sheet1!$A$1:$B$2\",\"title\":\"Sales\"}]";
+    tool.editSpreadsheet(null, "folder-1", "chart", ops);
+
+    String script = captureScript("xlsx", "result.xlsx");
+    assertTrue(script.contains("var oChart = oWorksheet.AddChart(\"Sheet1!$A$1:$B$2\", true, \"bar\", 2, 3600000, 2520000, 3, 0, 8, 0)"));
+    assertTrue(script.contains("oChart.SetTitle(\"Sales\", 14)"));
+  }
+
+  /**
+   * add_slide must create+append a slide and drive the {@code __setSlideText}
+   * helper with the title and the bullets array literal.
+   */
+  @Test
+  public void goldenScript_addSlide_createAndSetText() throws Exception {
+    Node parent = mock(Node.class);
+    when(session.getNodeByUUID("folder-1")).thenReturn(parent);
+    stubStorage("folder-1", "deck.pptx", "pptx-id");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("pptx"), eq("result.pptx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 1 });
+
+    String ops = "[{\"type\":\"add_slide\",\"title\":\"Review\",\"bullets\":[\"One\",\"Two\"]}]";
+    tool.editPresentation(null, "folder-1", "deck", ops, null, null);
+
+    String script = captureScript("pptx", "result.pptx");
+    // CREATE reuses the default slide, so no Api.CreateSlide()/AddSlide() pair here.
+    assertTrue(script.contains("var oSlide = oPresentation.GetSlideByIndex(0);"));
+    assertTrue(script.contains("__setSlideText(oSlide, \"Review\", [\"One\", \"Two\"]);"));
+  }
+
+  /**
+   * The MODIFY path must open the source asset with
+   * {@code builder.OpenFile("@@ASSET:input@@", "")} (not CreateFile) before
+   * applying operations.
+   */
+  @Test
+  public void goldenScript_modifyPath_opensAssetInsteadOfCreate() throws Exception {
+    Node node = stubExistingDocument("docx-1", "report.docx",
+                                     "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    when(editorService.runDocBuilderScript(anyString(), any(), eq("docx"), eq("result.docx"), eq(USER)))
+                                                                                                        .thenReturn(new byte[] { 1 });
+
+    tool.editDocument("docx-1", null, null, "[{\"type\":\"add_paragraph\",\"text\":\"More\"}]", null, null);
+
+    verify(editorService).saveNewVersion(eq(node), any(byte[].class), eq(USER));
+    String script = captureScript("docx", "result.docx");
+    assertTrue(script.contains("builder.OpenFile(\"@@ASSET:input@@\", \"\");"));
+    assertTrue("modify path must not CreateFile", !script.contains("builder.CreateFile"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private String captureScript(String format, String outputName) {
+    ArgumentCaptor<String> scriptCaptor = ArgumentCaptor.forClass(String.class);
+    verify(editorService).runDocBuilderScript(scriptCaptor.capture(), any(), eq(format), eq(outputName), eq(USER));
+    return scriptCaptor.getValue();
+  }
+
+  /**
+   * Stubs an existing document node resolvable by uuid, exposing a readable
+   * jcr:content/jcr:data stream (for the MODIFY OpenFile path) and a title.
+   */
+  private Node stubExistingDocument(String id, String title, String mimeType) throws Exception {
+    Node node = mock(Node.class);
+    when(session.getNodeByUUID(id)).thenReturn(node);
+    when(node.hasProperty("exo:title")).thenReturn(true);
+    Property titleProp = mock(Property.class);
+    when(titleProp.getString()).thenReturn(title);
+    when(node.getProperty("exo:title")).thenReturn(titleProp);
+    when(node.getPath()).thenReturn("/Users/john/" + title);
+
+    Node content = mock(Node.class);
+    when(node.getNode("jcr:content")).thenReturn(content);
+    Property dataProp = mock(Property.class);
+    when(content.getProperty("jcr:data")).thenReturn(dataProp);
+    when(dataProp.getStream()).thenReturn(new ByteArrayInputStream(new byte[] { 1, 2, 3, 4 }));
+    Property mimeProp = mock(Property.class);
+    when(content.getProperty("jcr:mimeType")).thenReturn(mimeProp);
+    when(mimeProp.getString()).thenReturn(mimeType);
+    return node;
+  }
+
+  private void stubTempNodeCreation(Node parent) throws Exception {
+    Node tmp = mock(Node.class);
+    Node resource = mock(Node.class);
+    ValueFactory valueFactory = mock(ValueFactory.class);
+    Value value = mock(Value.class);
+    when(parent.addNode(anyString(), eq("nt:file"))).thenReturn(tmp);
+    when(tmp.isNodeType("mix:referenceable")).thenReturn(false);
+    when(tmp.addNode("jcr:content", "nt:resource")).thenReturn(resource);
+    when(tmp.getSession()).thenReturn(session);
+    when(session.getValueFactory()).thenReturn(valueFactory);
+    when(valueFactory.createValue(any(InputStream.class))).thenReturn(value);
+  }
+
+  /**
+   * Stubs the Documents import path so it resolves the created file: the folder
+   * is readable, and the child listing returns nothing before the import then the
+   * new file afterwards (the poll).
+   */
+  private void stubStorage(String folderId, String expectedName, String newDocId) throws Exception {
+    when(documentFileService.getDocumentById(folderId, USER)).thenReturn(mock(AbstractNode.class));
+    when(documentFileService.getRootFolderOwnerId(folderId)).thenReturn(5L);
+
+    FileNode created = mock(FileNode.class);
+    when(created.getId()).thenReturn(newDocId);
+    when(created.getName()).thenReturn(expectedName);
+    when(created.getPath()).thenReturn("/Users/john/" + expectedName);
+    when(created.getMimeType()).thenReturn("application/octet-stream");
+    when(created.getParentFolderId()).thenReturn(folderId);
+    List<AbstractNode> afterImport = new ArrayList<>();
+    afterImport.add(created);
+
+    when(documentFileService.getFolderChildNodes(any(), anyInt(), anyInt(), anyLong())).thenReturn(Collections.emptyList())
+                                                                                       .thenReturn(afterImport);
+  }
+
+}

--- a/webapp/src/main/java/org/exoplatform/onlyoffice/OnlyofficeApplication.java
+++ b/webapp/src/main/java/org/exoplatform/onlyoffice/OnlyofficeApplication.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2003-2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.onlyoffice;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.PropertySource;
+
+import io.meeds.spring.AvailableIntegration;
+import io.meeds.spring.kernel.PortalApplicationContextInitializer;
+
+/**
+ * Makes the ONLYOFFICE editor add-on participate in the portal's shared Spring
+ * {@code ApplicationContext}, so its Spring-annotated beans (notably the
+ * {@code OnlyofficeMcpTool} {@code @Service}, active under the
+ * {@code mcp-server} profile) are discovered and can be collected by the
+ * mcp-server tool registry.
+ * <p>
+ * The add-on has NO JPA / Elasticsearch repositories and no Liquibase Spring
+ * configuration, so only the kernel and web integration modules are scanned in
+ * addition to the add-on package. The existing kernel wiring (declared in the
+ * add-on {@code configuration.xml}) is untouched: this Spring context lives
+ * alongside it, exactly like the Documents add-on does.
+ * <p>
+ * Because there is no DB layer at all, the Spring Boot DataSource / JPA /
+ * Liquibase auto-configurations (which are on the classpath transitively) are
+ * fully excluded. Otherwise Spring Boot would try to build an
+ * {@code entityManagerFactory} that depends on a {@code liquibase} bean whose
+ * default {@code classpath:/db/changelog/db.changelog-master.yaml} does not
+ * exist in this add-on, failing the context startup with a
+ * {@code BeanCreationException} at boot.
+ */
+@SpringBootApplication(scanBasePackages = {
+  OnlyofficeApplication.MODULE_NAME,
+  AvailableIntegration.KERNEL_MODULE,
+  AvailableIntegration.WEB_MODULE,
+}, exclude = {
+  LiquibaseAutoConfiguration.class,
+  DataSourceAutoConfiguration.class,
+  DataSourceTransactionManagerAutoConfiguration.class,
+  HibernateJpaAutoConfiguration.class,
+  JpaRepositoriesAutoConfiguration.class,
+})
+@PropertySource("classpath:application.properties")
+@PropertySource("classpath:application-common.properties")
+public class OnlyofficeApplication extends PortalApplicationContextInitializer {
+
+  public static final String MODULE_NAME = "org.exoplatform.onlyoffice";
+
+}


### PR DESCRIPTION
## What

Backport of #342 onto `develop`.

Adds OnlyOffice office-document MCP tools for the EVA AI agent, driven by the OnlyOffice Document Builder:
- `edit_document`, `edit_spreadsheet`, `edit_presentation` (create or modify), `generate_document` (from template), `convert_document`, `export_document_as_pdf`, `get_document_editor_link`
- A Spring bridge (`OnlyofficeApplication`) so the kernel-only add-on exposes the `@Service ... McpToolPlugin` beans, plus `ai-tool-definitions.json`.

Fixes folded in: xlsx→PDF active-sheet re-activation, pptx create text-fill/blank-slide fixes, `SessionProvider` binding for the modify path, `Api.CreateTable` argument order, and EVA chat-attachment image support (with a fallback when the model invents a placeholder `url`).

Companion PR: exoplatform/documents#2021 (backport `backport/EXO-88456-documents-mcp-tools`), same ticket EXO-88456. Also related: platform-private-distributions#588, which removes the now-duplicated enterprise-only tool once these land.

## Backport notes

Cherry-picked the squashed source commit `d4aaa68b` (6 commits squashed into the merge to `feature/ai-contribution`) onto `develop` — applied with **no conflicts**. One manual fix in `services/pom.xml`: the source branch pinned the new `documents-api` and `mcp-server-tools` dependencies to the branch-specific `7.3.x-ai-contribution-SNAPSHOT` line (one comment noting "the platform-managed 7.3.x-SNAPSHOT does not have it yet" for `UploadToolUtils`). Repinned both to the regular `7.3.x-SNAPSHOT` line instead:
- `mcp-server`'s current `develop` already ships `UploadToolUtils` (verified the class/API is present) — that comment is stale, it landed on mainline via a prior backport (EXO-88348).
- The `documents-api` classes actually used here (`DocumentFileService`, `AbstractNode`, `DocumentFolderFilter`, `FileNode`, and the specific methods called) are all pre-existing on `documents`' `develop`, not new MCP-only additions — no dependency on the companion documents backport landing first.

## Test

- `mvn -pl services,webapp -am -Dcheckstyle.skip=true -Dlicense.skip=true -DskipTests compile` → BUILD SUCCESS (against the regular `7.3.x-SNAPSHOT` dependency line)
- `mvn -pl services -Dcheckstyle.skip=true -Dlicense.skip=true -Dtest=OnlyofficeMcpToolTest,OnlyofficeEditorServiceTest test` → 24 + 63 tests, 0 failures/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
